### PR TITLE
Supress AVX within Eigen for Cygwin and MinGW

### DIFF
--- a/src/include/falconn/core/cosine_distance.h
+++ b/src/include/falconn/core/cosine_distance.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <Eigen/Dense>
+#include "../eigen_wrapper.h"
 
 namespace falconn {
 namespace core {

--- a/src/include/falconn/core/euclidean_distance.h
+++ b/src/include/falconn/core/euclidean_distance.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <Eigen/Dense>
+#include "../eigen_wrapper.h"
 
 namespace falconn {
 namespace core {

--- a/src/include/falconn/core/hyperplane_hash.h
+++ b/src/include/falconn/core/hyperplane_hash.h
@@ -8,7 +8,7 @@
 #include <random>
 #include <vector>
 
-#include <Eigen/Dense>
+#include "../eigen_wrapper.h"
 
 #include "data_storage.h"
 #include "heap.h"

--- a/src/include/falconn/core/polytope_hash.h
+++ b/src/include/falconn/core/polytope_hash.h
@@ -9,7 +9,8 @@
 #include <memory>
 #include <random>
 #include <vector>
-#include <Eigen/Dense>
+
+#include "../eigen_wrapper.h"
 
 #include "../ffht/fht_header_only.h"
 #include "data_storage.h"

--- a/src/include/falconn/core/prefetchers.h
+++ b/src/include/falconn/core/prefetchers.h
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
+#include "../eigen_wrapper.h"
 
 namespace falconn {
 namespace core {

--- a/src/include/falconn/eigen_wrapper.h
+++ b/src/include/falconn/eigen_wrapper.h
@@ -1,0 +1,15 @@
+#undef STRIP_EIGEN_AVX
+#if defined(__AVX__) && (defined(__CYGWIN__) || defined(__MINGW32__))
+#define STRIP_EIGEN_AVX
+#endif
+
+#ifdef STRIP_EIGEN_AVX
+#undef __AVX__
+#warning "Stripping AVX support from Eigen"
+#endif
+
+#include <Eigen/Dense>
+
+#ifdef STRIP_EIGEN_AVX
+#define __AVX__
+#endif

--- a/src/include/falconn/falconn_global.h
+++ b/src/include/falconn/falconn_global.h
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
+#include "eigen_wrapper.h"
 
 namespace falconn {
 

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -1,6 +1,10 @@
 #ifndef __WRAPPER_H__
 #define __WRAPPER_H__
 
+#if defined(__CYGWIN__) || defined(__MINGW32__)
+#error "Not supported!"
+#endif
+
 #include <array>
 #include <cstdint>
 #include <memory>

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -1,9 +1,6 @@
 #ifndef __WRAPPER_H__
 #define __WRAPPER_H__
 
-#if defined(__CYGWIN__) || defined(__MINGW32__)
-#error "Not supported!"
-#endif
 
 #include <array>
 #include <cstdint>
@@ -11,7 +8,7 @@
 #include <type_traits>
 #include <vector>
 
-#include <Eigen/Dense>
+#include "eigen_wrapper.h"
 
 #include "falconn_global.h"
 

--- a/src/python/wrapper/python_wrapper.h
+++ b/src/python/wrapper/python_wrapper.h
@@ -6,8 +6,7 @@
 #include <string>
 #include <vector>
 
-#include <Eigen/Dense>
-
+#include "falconn/eigen_wrapper.h"
 #include "falconn/falconn_global.h"
 #include "falconn/lsh_nn_table.h"
 


### PR DESCRIPTION
We achieve subj by wrapping `#include <Eigen/Dense>` in a couple of macroses.
