### PR TITLE
Several updates for v1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ PYTHON_SWIG_DIR=python_swig
 PYTHON_PKG_DIR=python_pkg
 DOC_DIR=doc
 
-ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(INC_DIR)/core/euclidean_distance.h $(INC_DIR)/core/composite_hash_table.h $(INC_DIR)/core/stl_hash_table.h $(INC_DIR)/core/polytope_hash.h $(INC_DIR)/core/flat_hash_table.h $(INC_DIR)/core/probing_hash_table.h $(INC_DIR)/core/hyperplane_hash.h $(INC_DIR)/core/heap.h $(INC_DIR)/core/prefetchers.h $(INC_DIR)/core/incremental_sorter.h $(INC_DIR)/core/lsh_function_helpers.h $(INC_DIR)/core/hash_table_helpers.h $(INC_DIR)/core/data_storage.h $(INC_DIR)/core/nn_query.h $(INC_DIR)/lsh_nn_table.h $(INC_DIR)/wrapper/cpp_wrapper_impl.h $(INC_DIR)/falconn_global.h $(TEST_DIR)/test_utils.h  $(INC_DIR)/core/data_transformation.h $(PYTHON_DIR)/wrapper/python_wrapper.h
+ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(INC_DIR)/core/euclidean_distance.h $(INC_DIR)/core/composite_hash_table.h $(INC_DIR)/core/stl_hash_table.h $(INC_DIR)/core/polytope_hash.h $(INC_DIR)/core/flat_hash_table.h $(INC_DIR)/core/probing_hash_table.h $(INC_DIR)/core/hyperplane_hash.h $(INC_DIR)/core/heap.h $(INC_DIR)/core/prefetchers.h $(INC_DIR)/core/incremental_sorter.h $(INC_DIR)/core/lsh_function_helpers.h $(INC_DIR)/core/hash_table_helpers.h $(INC_DIR)/core/data_storage.h $(INC_DIR)/core/nn_query.h $(INC_DIR)/lsh_nn_table.h $(INC_DIR)/wrapper/cpp_wrapper_impl.h $(INC_DIR)/falconn_global.h $(TEST_DIR)/test_utils.h  $(INC_DIR)/core/data_transformation.h $(PYTHON_DIR)/wrapper/python_wrapper.h $(INC_DIR)/core/bit_packed_vector.h
 
-CXX=g++
+CXX=g++-5
 CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -march=native -O3 -I external/eigen -I src/include
 SWIG=swig3.0
 NUMPY_INCLUDE_DIR=/usr/local/lib/python2.7/site-packages/numpy/core/include
@@ -149,7 +149,12 @@ $(TEST_BIN_DIR)/data_storage_test: $(TEST_DIR)/data_storage_test.cc $(ALL_HEADER
 	$(CXX) $(CXXFLAGS) -I $(GTEST_DIR)/include -c -o obj/data_storage_test.o $(TEST_DIR)/data_storage_test.cc
 	$(CXX) $(CXXFLAGS) -o $(TEST_BIN_DIR)/data_storage_test obj/gtest_main.o obj/gtest-all.o obj/data_storage_test.o -pthread
 
-run_all_cpp_tests: $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/euclidean_distance_test $(TEST_BIN_DIR)/flat_hash_table_test $(TEST_BIN_DIR)/probing_hash_table_test $(TEST_BIN_DIR)/stl_hash_table_test $(TEST_BIN_DIR)/composite_hash_table_test $(TEST_BIN_DIR)/polytope_hash_test $(TEST_BIN_DIR)/hyperplane_hash_test $(TEST_BIN_DIR)/lsh_table_test $(TEST_BIN_DIR)/heap_test $(TEST_BIN_DIR)/incremental_sorter_test $(TEST_BIN_DIR)/nn_query_test $(TEST_BIN_DIR)/cpp_wrapper_test $(TEST_BIN_DIR)/data_transformation_test $(TEST_BIN_DIR)/data_storage_test
+$(TEST_BIN_DIR)/bit_packed_vector_test: $(TEST_DIR)/bit_packed_vector_test.cc $(ALL_HEADERS) obj/gtest-all.o obj/gtest_main.o
+	mkdir -p $(TEST_BIN_DIR)
+	$(CXX) $(CXXFLAGS) -I $(GTEST_DIR)/include -c -o obj/bit_packed_vector_test.o $(TEST_DIR)/bit_packed_vector_test.cc
+	$(CXX) $(CXXFLAGS) -o $(TEST_BIN_DIR)/bit_packed_vector_test obj/gtest_main.o obj/gtest-all.o obj/bit_packed_vector_test.o -pthread
+
+run_all_cpp_tests: $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/euclidean_distance_test $(TEST_BIN_DIR)/flat_hash_table_test $(TEST_BIN_DIR)/probing_hash_table_test $(TEST_BIN_DIR)/stl_hash_table_test $(TEST_BIN_DIR)/composite_hash_table_test $(TEST_BIN_DIR)/polytope_hash_test $(TEST_BIN_DIR)/hyperplane_hash_test $(TEST_BIN_DIR)/lsh_table_test $(TEST_BIN_DIR)/heap_test $(TEST_BIN_DIR)/incremental_sorter_test $(TEST_BIN_DIR)/nn_query_test $(TEST_BIN_DIR)/cpp_wrapper_test $(TEST_BIN_DIR)/data_transformation_test $(TEST_BIN_DIR)/data_storage_test $(TEST_BIN_DIR)/bit_packed_vector_test
 	./$(TEST_BIN_DIR)/cosine_distance_test
 	./$(TEST_BIN_DIR)/euclidean_distance_test
 	./$(TEST_BIN_DIR)/flat_hash_table_test
@@ -165,6 +170,7 @@ run_all_cpp_tests: $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/euclidea
 	./$(TEST_BIN_DIR)/cpp_wrapper_test
 	./$(TEST_BIN_DIR)/data_transformation_test
 	./$(TEST_BIN_DIR)/data_storage_test
+	./$(TEST_BIN_DIR)/bit_packed_vector_test
 
 run_all_python_tests: $(PYTHON_DIR)/test/wrapper_test.py
 	py.test src/python/test/wrapper_test.py

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ PYTHON_SWIG_DIR=python_swig
 PYTHON_PKG_DIR=python_pkg
 DOC_DIR=doc
 
-ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(INC_DIR)/core/euclidean_distance.h $(INC_DIR)/core/composite_hash_table.h $(INC_DIR)/core/stl_hash_table.h $(INC_DIR)/core/polytope_hash.h $(INC_DIR)/core/flat_hash_table.h $(INC_DIR)/core/probing_hash_table.h $(INC_DIR)/core/hyperplane_hash.h $(INC_DIR)/core/heap.h $(INC_DIR)/core/prefetchers.h $(INC_DIR)/core/incremental_sorter.h $(INC_DIR)/core/lsh_function_helpers.h $(INC_DIR)/core/hash_table_helpers.h $(INC_DIR)/core/data_storage.h $(INC_DIR)/core/nn_query.h $(INC_DIR)/lsh_nn_table.h $(INC_DIR)/wrapper/cpp_wrapper_impl.h $(INC_DIR)/falconn_global.h $(TEST_DIR)/test_utils.h  $(INC_DIR)/core/data_transformation.h $(PYTHON_DIR)/wrapper/python_wrapper.h $(INC_DIR)/core/bit_packed_vector.h
+ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(INC_DIR)/core/euclidean_distance.h $(INC_DIR)/core/composite_hash_table.h $(INC_DIR)/core/stl_hash_table.h $(INC_DIR)/core/polytope_hash.h $(INC_DIR)/core/flat_hash_table.h $(INC_DIR)/core/probing_hash_table.h $(INC_DIR)/core/hyperplane_hash.h $(INC_DIR)/core/heap.h $(INC_DIR)/core/prefetchers.h $(INC_DIR)/core/incremental_sorter.h $(INC_DIR)/core/lsh_function_helpers.h $(INC_DIR)/core/hash_table_helpers.h $(INC_DIR)/core/data_storage.h $(INC_DIR)/core/nn_query.h $(INC_DIR)/lsh_nn_table.h $(INC_DIR)/wrapper/cpp_wrapper_impl.h $(INC_DIR)/falconn_global.h $(TEST_DIR)/test_utils.h  $(INC_DIR)/core/data_transformation.h $(PYTHON_DIR)/wrapper/python_wrapper.h $(INC_DIR)/core/bit_packed_vector.h $(INC_DIR)/core/bit_packed_flat_hash_table.h
 
 CXX=g++-5
 CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -march=native -O3 -I external/eigen -I src/include
+#CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -march=native -g -I external/eigen -I src/include
 SWIG=swig3.0
 NUMPY_INCLUDE_DIR=/usr/local/lib/python2.7/site-packages/numpy/core/include
 
@@ -154,7 +155,12 @@ $(TEST_BIN_DIR)/bit_packed_vector_test: $(TEST_DIR)/bit_packed_vector_test.cc $(
 	$(CXX) $(CXXFLAGS) -I $(GTEST_DIR)/include -c -o obj/bit_packed_vector_test.o $(TEST_DIR)/bit_packed_vector_test.cc
 	$(CXX) $(CXXFLAGS) -o $(TEST_BIN_DIR)/bit_packed_vector_test obj/gtest_main.o obj/gtest-all.o obj/bit_packed_vector_test.o -pthread
 
-run_all_cpp_tests: $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/euclidean_distance_test $(TEST_BIN_DIR)/flat_hash_table_test $(TEST_BIN_DIR)/probing_hash_table_test $(TEST_BIN_DIR)/stl_hash_table_test $(TEST_BIN_DIR)/composite_hash_table_test $(TEST_BIN_DIR)/polytope_hash_test $(TEST_BIN_DIR)/hyperplane_hash_test $(TEST_BIN_DIR)/lsh_table_test $(TEST_BIN_DIR)/heap_test $(TEST_BIN_DIR)/incremental_sorter_test $(TEST_BIN_DIR)/nn_query_test $(TEST_BIN_DIR)/cpp_wrapper_test $(TEST_BIN_DIR)/data_transformation_test $(TEST_BIN_DIR)/data_storage_test $(TEST_BIN_DIR)/bit_packed_vector_test
+$(TEST_BIN_DIR)/bit_packed_flat_hash_table_test: $(TEST_DIR)/bit_packed_flat_hash_table_test.cc $(ALL_HEADERS) obj/gtest-all.o obj/gtest_main.o
+	mkdir -p $(TEST_BIN_DIR)
+	$(CXX) $(CXXFLAGS) -I $(GTEST_DIR)/include -c -o obj/bit_packed_flat_hash_table_test.o $(TEST_DIR)/bit_packed_flat_hash_table_test.cc
+	$(CXX) $(CXXFLAGS) -o $(TEST_BIN_DIR)/bit_packed_flat_hash_table_test obj/gtest_main.o obj/gtest-all.o obj/bit_packed_flat_hash_table_test.o -pthread
+
+run_all_cpp_tests: $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/euclidean_distance_test $(TEST_BIN_DIR)/flat_hash_table_test $(TEST_BIN_DIR)/probing_hash_table_test $(TEST_BIN_DIR)/stl_hash_table_test $(TEST_BIN_DIR)/composite_hash_table_test $(TEST_BIN_DIR)/polytope_hash_test $(TEST_BIN_DIR)/hyperplane_hash_test $(TEST_BIN_DIR)/lsh_table_test $(TEST_BIN_DIR)/heap_test $(TEST_BIN_DIR)/incremental_sorter_test $(TEST_BIN_DIR)/nn_query_test $(TEST_BIN_DIR)/cpp_wrapper_test $(TEST_BIN_DIR)/data_transformation_test $(TEST_BIN_DIR)/data_storage_test $(TEST_BIN_DIR)/bit_packed_vector_test $(TEST_BIN_DIR)/bit_packed_flat_hash_table_test
 	./$(TEST_BIN_DIR)/cosine_distance_test
 	./$(TEST_BIN_DIR)/euclidean_distance_test
 	./$(TEST_BIN_DIR)/flat_hash_table_test
@@ -171,6 +177,7 @@ run_all_cpp_tests: $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/euclidea
 	./$(TEST_BIN_DIR)/data_transformation_test
 	./$(TEST_BIN_DIR)/data_storage_test
 	./$(TEST_BIN_DIR)/bit_packed_vector_test
+	./$(TEST_BIN_DIR)/bit_packed_flat_hash_table_test
 
 run_all_python_tests: $(PYTHON_DIR)/test/wrapper_test.py
 	py.test src/python/test/wrapper_test.py

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,8 @@ DOC_DIR=doc
 
 ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(INC_DIR)/core/euclidean_distance.h $(INC_DIR)/core/composite_hash_table.h $(INC_DIR)/core/stl_hash_table.h $(INC_DIR)/core/polytope_hash.h $(INC_DIR)/core/flat_hash_table.h $(INC_DIR)/core/probing_hash_table.h $(INC_DIR)/core/hyperplane_hash.h $(INC_DIR)/core/heap.h $(INC_DIR)/core/prefetchers.h $(INC_DIR)/core/incremental_sorter.h $(INC_DIR)/core/lsh_function_helpers.h $(INC_DIR)/core/hash_table_helpers.h $(INC_DIR)/core/data_storage.h $(INC_DIR)/core/nn_query.h $(INC_DIR)/lsh_nn_table.h $(INC_DIR)/wrapper/cpp_wrapper_impl.h $(INC_DIR)/falconn_global.h $(TEST_DIR)/test_utils.h  $(INC_DIR)/core/data_transformation.h $(PYTHON_DIR)/wrapper/python_wrapper.h $(INC_DIR)/core/bit_packed_vector.h $(INC_DIR)/core/bit_packed_flat_hash_table.h
 
-CXX=g++-5
+CXX=g++
 CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -march=native -O3 -I external/eigen -I src/include
-#CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -march=native -g -I external/eigen -I src/include
 SWIG=swig3.0
 NUMPY_INCLUDE_DIR=/usr/local/lib/python2.7/site-packages/numpy/core/include
 

--- a/src/benchmark/random_benchmark.cc
+++ b/src/benchmark/random_benchmark.cc
@@ -27,6 +27,7 @@ using falconn::LSHConstructionParameters;
 using falconn::LSHFamily;
 using falconn::LSHNearestNeighborTable;
 using falconn::QueryStatistics;
+using falconn::StorageHashTable;
 
 typedef falconn::DenseVector<float> Vec;
 
@@ -191,6 +192,7 @@ int main() {
     params_hp.dimension = d;
     params_hp.lsh_family = LSHFamily::Hyperplane;
     params_hp.distance_function = DistanceFunction::NegativeInnerProduct;
+    params_hp.storage_hash_table = StorageHashTable::FlatHashTable;
     params_hp.k = 19;
     params_hp.l = 10;
     params_hp.seed = seed ^ 833840234;
@@ -223,6 +225,7 @@ int main() {
     params_cp.dimension = d;
     params_cp.lsh_family = LSHFamily::CrossPolytope;
     params_cp.distance_function = DistanceFunction::NegativeInnerProduct;
+    params_cp.storage_hash_table = StorageHashTable::FlatHashTable;
     params_cp.k = 3;
     params_cp.l = 10;
     params_cp.last_cp_dimension = 16;

--- a/src/benchmark/random_benchmark.cc
+++ b/src/benchmark/random_benchmark.cc
@@ -114,6 +114,12 @@ int main() {
     double r = std::sqrt(2.0) / 2.0;    // distance to planted query
     uint64_t seed = 119417657;
 
+    // Common LSH parameters
+    int num_tables = 10;
+    int num_setup_threads = 0;
+    StorageHashTable storage_hash_table = StorageHashTable::FlatHashTable;
+    DistanceFunction distance_function = DistanceFunction::NegativeInnerProduct;
+
     cout << sepline << endl;
     cout << "FALCONN C++ random data benchmark" << endl;
     cout << "Data set parameters: " << endl;
@@ -191,10 +197,11 @@ int main() {
     LSHConstructionParameters params_hp;
     params_hp.dimension = d;
     params_hp.lsh_family = LSHFamily::Hyperplane;
-    params_hp.distance_function = DistanceFunction::NegativeInnerProduct;
-    params_hp.storage_hash_table = StorageHashTable::FlatHashTable;
+    params_hp.distance_function = distance_function;
+    params_hp.storage_hash_table = storage_hash_table;
     params_hp.k = 19;
-    params_hp.l = 10;
+    params_hp.l = num_tables;
+    params_hp.num_setup_threads = num_setup_threads;
     params_hp.seed = seed ^ 833840234;
   
     cout << "Hyperplane hash" << endl << endl;
@@ -224,12 +231,13 @@ int main() {
     LSHConstructionParameters params_cp;
     params_cp.dimension = d;
     params_cp.lsh_family = LSHFamily::CrossPolytope;
-    params_cp.distance_function = DistanceFunction::NegativeInnerProduct;
-    params_cp.storage_hash_table = StorageHashTable::FlatHashTable;
+    params_cp.distance_function = distance_function;
+    params_cp.storage_hash_table = storage_hash_table;
     params_cp.k = 3;
-    params_cp.l = 10;
+    params_cp.l = num_tables;
     params_cp.last_cp_dimension = 16;
     params_cp.num_rotations = 3;
+    params_cp.num_setup_threads = num_setup_threads;
     params_cp.seed = seed ^ 833840234;
   
     cout << "Cross polytope hash" << endl << endl;

--- a/src/include/falconn/core/bit_packed_flat_hash_table.h
+++ b/src/include/falconn/core/bit_packed_flat_hash_table.h
@@ -36,6 +36,11 @@ class BitPackedFlatHashTable {
             "Number of items must be at least 1.");
       }
     }
+    
+    BitPackedFlatHashTable<KeyType, ValueType, IndexType>* new_hash_table() {
+      return new BitPackedFlatHashTable<KeyType, ValueType, IndexType>(
+          num_buckets_, num_items_);
+    }
    
    private:
     IndexType num_buckets_ = 0;
@@ -44,6 +49,8 @@ class BitPackedFlatHashTable {
 
   class Iterator {
    public:
+    Iterator() : index_(0), parent_(nullptr) {}
+
     Iterator(ValueType index, const BitPackedFlatHashTable* parent)
         : index_(index), parent_(parent) {}
 
@@ -79,6 +86,7 @@ class BitPackedFlatHashTable {
         num_items_(num_items),
         bucket_start_(num_buckets, log2ceil(num_items)),
         indices_(num_items, log2ceil(num_items)) {
+    //printf("num_buckets = %d  num_items_ = %d\n", num_buckets_, num_items_);
     if (num_buckets_ < 1) {
       throw BitPackedFlatHashTableError(
           "Number of buckets must be at least 1.");
@@ -103,7 +111,7 @@ class BitPackedFlatHashTable {
     std::vector<ValueType> tmp_indices(keys.size());
     for(IndexType ii = 0; ii < static_cast<IndexType>(tmp_indices.size());
         ++ii) {
-      if (keys[ii] >= num_buckets_ || keys[ii] < 0) {
+      if (static_cast<IndexType>(keys[ii]) >= num_buckets_ || keys[ii] < 0) {
         throw BitPackedFlatHashTableError("Key value out of range.");
       }
       tmp_indices[ii] = ii;
@@ -116,6 +124,8 @@ class BitPackedFlatHashTable {
     }
 
     IndexType cur_index = 0;
+    std::vector<bool> bucket_empty(num_buckets_, true);
+
     while (cur_index < static_cast<IndexType>(tmp_indices.size())) {
       IndexType end_index = cur_index;
       do {
@@ -125,26 +135,15 @@ class BitPackedFlatHashTable {
                    == keys[tmp_indices[end_index]]);
 
       bucket_start_.set(keys[tmp_indices[cur_index]], cur_index);
+      bucket_empty[keys[tmp_indices[cur_index]]] = false;
       cur_index = end_index;
     }
 
-    // Fill in bucket start values of empty buckets
-    IndexType last_initial_zero_bucket = 0;
-    for (IndexType ii = 1; ii < num_buckets_; ++ii) {
-      if (bucket_start_.get(ii) == 0) {
-        last_initial_zero_bucket = ii;
-      } else {
-        break;
-      }
-    }
-    if (bucket_start_.get(num_buckets_ - 1) == 0) {
+    if (bucket_empty[num_buckets_ - 1]) {
       bucket_start_.set(num_buckets_ - 1, num_items_);
     }
     for (IndexType ii = num_buckets_ - 2; ii >= 0; --ii) {
-      if (ii == last_initial_zero_bucket) {
-        break;
-      }
-      if (bucket_start_.get(ii) == 0) {
+      if (bucket_empty[ii]) {
         bucket_start_.set(ii, bucket_start_.get(ii + 1));
       }
     }
@@ -153,10 +152,11 @@ class BitPackedFlatHashTable {
   std::pair<Iterator, Iterator> retrieve(const KeyType& key) {
     ValueType start = bucket_start_.get(key);
     ValueType end = num_items_;
-    if (key < num_buckets_ - 1) {
+    if (static_cast<IndexType>(key) < num_buckets_ - 1) {
       end = bucket_start_.get(key + 1);
     }
-    //printf("start: %lld  end %lld\n", start, end);
+    //printf("retrieve for key %u\n", key);
+    //printf("  start: %lld  end %lld\n", start, end);
     return std::make_pair(Iterator(start, this), Iterator(end, this));
   }
  

--- a/src/include/falconn/core/bit_packed_flat_hash_table.h
+++ b/src/include/falconn/core/bit_packed_flat_hash_table.h
@@ -1,0 +1,189 @@
+#ifndef __BIT_PACKED_FLAT_HASH_TABLE_H__
+#define __BIT_PACKED_FLAT_HASH_TABLE_H__
+
+#include <algorithm>
+#include <vector>
+
+#include "bit_packed_vector.h"
+#include "hash_table_helpers.h"
+#include "math_helpers.h"
+
+namespace falconn {
+namespace core {
+
+class BitPackedFlatHashTableError : public HashTableError {
+ public:
+  BitPackedFlatHashTableError(const char* msg) : HashTableError(msg) {}
+};
+
+
+template<
+typename KeyType,
+typename ValueType = int_fast64_t,
+typename IndexType = int_fast64_t>
+class BitPackedFlatHashTable {
+ public:
+  class Factory {
+   public:
+    Factory(IndexType num_buckets, ValueType num_items)
+        : num_buckets_(num_buckets), num_items_(num_items) {
+      if (num_buckets_ < 1) {
+        throw BitPackedFlatHashTableError(
+            "Number of buckets must be at least 1.");
+      }
+      if (num_items_ < 1) {
+        throw BitPackedFlatHashTableError(
+            "Number of items must be at least 1.");
+      }
+    }
+   
+   private:
+    IndexType num_buckets_ = 0;
+    ValueType num_items_ = 0;
+  };
+
+  class Iterator {
+   public:
+    Iterator(ValueType index, const BitPackedFlatHashTable* parent)
+        : index_(index), parent_(parent) {}
+
+    ValueType operator * () const {
+      return parent_->indices_.get(index_);
+    }
+
+    bool operator != (const Iterator& iter) const {
+      if (parent_ != iter.parent_) {
+        return false;
+      } else {
+        return index_ != iter.index_;
+      }
+    }
+
+    bool operator == (const Iterator& iter) const {
+      return !(*this != iter);
+    }
+
+    Iterator& operator++ () {
+      index_ += 1;
+      return *this;
+    }
+   
+   private:
+    ValueType index_;
+    const BitPackedFlatHashTable* parent_;
+  };
+ 
+
+  BitPackedFlatHashTable(IndexType num_buckets, ValueType num_items)
+      : num_buckets_(num_buckets),
+        num_items_(num_items),
+        bucket_start_(num_buckets, log2ceil(num_items)),
+        indices_(num_items, log2ceil(num_items)) {
+    if (num_buckets_ < 1) {
+      throw BitPackedFlatHashTableError(
+          "Number of buckets must be at least 1.");
+    }
+    if (num_items_ < 1) {
+      throw BitPackedFlatHashTableError(
+          "Number of items must be at least 1.");
+    }
+  }
+  
+  void add_entries(const std::vector<KeyType>& keys) {
+    if (entries_added_) {
+      throw BitPackedFlatHashTableError("Entries were already added.");
+    }
+    entries_added_ = true;
+    if (static_cast<ValueType>(keys.size()) != num_items_) {
+      throw BitPackedFlatHashTableError(
+          "Incorrect number of items in add_entries.");
+    }
+    
+    KeyComparator comp(keys);
+    std::vector<ValueType> tmp_indices(keys.size());
+    for(IndexType ii = 0; ii < static_cast<IndexType>(tmp_indices.size());
+        ++ii) {
+      if (keys[ii] >= num_buckets_ || keys[ii] < 0) {
+        throw BitPackedFlatHashTableError("Key value out of range.");
+      }
+      tmp_indices[ii] = ii;
+    }
+    std::sort(tmp_indices.begin(), tmp_indices.end(), comp);
+    
+    for(IndexType ii = 0; ii < static_cast<IndexType>(tmp_indices.size());
+        ++ii) {
+      indices_.set(ii, tmp_indices[ii]);
+    }
+
+    IndexType cur_index = 0;
+    while (cur_index < static_cast<IndexType>(tmp_indices.size())) {
+      IndexType end_index = cur_index;
+      do {
+        end_index += 1;
+      } while (end_index < static_cast<IndexType>(tmp_indices.size())
+               && keys[tmp_indices[cur_index]]
+                   == keys[tmp_indices[end_index]]);
+
+      bucket_start_.set(keys[tmp_indices[cur_index]], cur_index);
+      cur_index = end_index;
+    }
+
+    // Fill in bucket start values of empty buckets
+    IndexType last_initial_zero_bucket = 0;
+    for (IndexType ii = 1; ii < num_buckets_; ++ii) {
+      if (bucket_start_.get(ii) == 0) {
+        last_initial_zero_bucket = ii;
+      } else {
+        break;
+      }
+    }
+    if (bucket_start_.get(num_buckets_ - 1) == 0) {
+      bucket_start_.set(num_buckets_ - 1, num_items_);
+    }
+    for (IndexType ii = num_buckets_ - 2; ii >= 0; --ii) {
+      if (ii == last_initial_zero_bucket) {
+        break;
+      }
+      if (bucket_start_.get(ii) == 0) {
+        bucket_start_.set(ii, bucket_start_.get(ii + 1));
+      }
+    }
+  }
+  
+  std::pair<Iterator, Iterator> retrieve(const KeyType& key) {
+    ValueType start = bucket_start_.get(key);
+    ValueType end = num_items_;
+    if (key < num_buckets_ - 1) {
+      end = bucket_start_.get(key + 1);
+    }
+    //printf("start: %lld  end %lld\n", start, end);
+    return std::make_pair(Iterator(start, this), Iterator(end, this));
+  }
+ 
+ private:
+  IndexType num_buckets_ = 0;
+  ValueType num_items_ = 0;
+  bool entries_added_ = false;
+
+  // start of the respective hash bucket
+  BitPackedVector<ValueType> bucket_start_;
+  // point indices
+  BitPackedVector<ValueType> indices_;
+  
+  class KeyComparator {
+   public:
+    KeyComparator(const std::vector<KeyType>& keys) : keys_(keys) {}
+
+    bool operator() (IndexType ii, IndexType jj) {
+      return keys_[ii] < keys_[jj];
+    }
+
+    const std::vector<KeyType>& keys_;
+  };
+};
+
+
+}  // namespace core
+}  // namespace falconn
+
+#endif

--- a/src/include/falconn/core/bit_packed_vector.h
+++ b/src/include/falconn/core/bit_packed_vector.h
@@ -1,0 +1,158 @@
+#ifndef __BIT_PACKED_VECTOR_H__
+#define __BIT_PACKED_VECTOR_H__
+
+#include <cstdint>
+#include <vector>
+
+#include "../falconn_global.h"
+
+namespace falconn {
+namespace core {
+
+class BitPackedVectorError : public FalconnError {
+ public:
+  BitPackedVectorError(const char* msg) : FalconnError(msg) {}
+};
+
+
+template <
+typename DataType,
+typename StorageType = uint64_t,
+typename IndexType = int_fast64_t>
+class BitPackedVector {
+ public:
+  BitPackedVector(int_fast64_t num_items, int_fast64_t item_size)
+      : num_items_(num_items), item_size_(item_size) {
+    if (item_size > 8 * static_cast<int_fast64_t>(sizeof(DataType))) {
+      throw BitPackedVectorError("DataType too small for the number of bits "
+          "specified.");
+    }
+    if (item_size > num_bits_per_package_) {
+      throw BitPackedVectorError("Currently the item size must be at most the "
+          "data package size.");
+    }
+    if (num_items > std::numeric_limits<IndexType>::max()) {
+      throw BitPackedVectorError("IndexType too small for the vector size "
+          "specified.");
+    }
+    num_data_packets_ = (num_items_ * item_size_) / num_bits_per_package_;
+    if ((num_items_ * item_size_) % num_bits_per_package_ != 0) {
+      num_data_packets_ += 1;
+    }
+    data_.resize(num_data_packets_);
+    for (int_fast64_t ii = 0; ii < num_data_packets_; ++ii) {
+      data_[ii] = 0;
+    }
+  }
+
+  // For (potential) performance reasons, get() does no bounds checking.
+  DataType get(IndexType index) {
+    int_fast64_t first_bit = index * item_size_;
+    int_fast64_t first_package = first_bit / num_bits_per_package_;
+    int_fast64_t offset_in_package =
+        first_bit - first_package * num_bits_per_package_;
+    StorageType result = data_[first_package];
+    // Move first bits to the beginning of the result.
+    result >>= offset_in_package;
+    // Check if we need to go to the next package to get all the bits.
+    // (Currently the class assumes that an item occupies at most two packages.)
+    int_fast64_t remaining_bits =
+        num_bits_per_package_ - (offset_in_package + item_size_);
+    if (remaining_bits >= 0) {
+      // Zero out the remaining bits
+      //printf("index %lld  remaining_bits %lld  result %llu\n", index,
+      //    remaining_bits, result);
+      result <<= remaining_bits + offset_in_package;
+      result >>= remaining_bits + offset_in_package;
+      //printf("index %lld  remaining_bits %lld  result %llu\n", index,
+      //    remaining_bits, result);
+    } else {
+      //printf("get: in else case\n");
+      // remaining_bits is negative here.
+      StorageType tmp = data_[first_package + 1];
+      tmp <<= (num_bits_per_package_ + remaining_bits);
+      tmp >>= (num_bits_per_package_ + remaining_bits);
+      result |= (tmp << (item_size_ + remaining_bits));
+    }
+    return static_cast<DataType>(result);
+  }
+  
+  // For (potential) performance reasons, set() does no bounds checking.
+  void set(IndexType index, DataType value) {
+    int_fast64_t first_bit = index * item_size_;
+    int_fast64_t first_package = first_bit / num_bits_per_package_;
+    int_fast64_t offset_in_package =
+        first_bit - first_package * num_bits_per_package_;
+    /*printf("set index %lld  value %lld  offset_in_package %lld\n", index,
+        value, offset_in_package);
+    printf("set index %lld  value %lld  data_[first_package] %llu\n",
+        index, value, data_[first_package]);
+    printf("set index %lld  value %lld  shift %lld  shifted %llu\n",
+        index, value, num_bits_per_package_ - offset_in_package,
+        (data_[first_package] << (num_bits_per_package_ - offset_in_package
+            - 1)) << 1);*/
+    // Avoid shift with shift_count == bit_width.
+    StorageType new_package, tmp;
+    if (offset_in_package != 0) {
+      new_package = data_[first_package]
+          << (num_bits_per_package_ - offset_in_package);
+      new_package >>= (num_bits_per_package_ - offset_in_package);
+      tmp = value;
+      /*printf("set index %lld  value %lld  new_package %llu  tmp %llu\n",
+          index, value, new_package, tmp);*/
+      new_package |= tmp << offset_in_package;
+    } else {
+      new_package = value;
+    }
+    /*StorageType new_package =
+        (data_[first_package] << (num_bits_per_package_ - offset_in_package
+            - 1));
+    new_package <<= 1;
+    new_package >>= (num_bits_per_package_ - offset_in_package - 1);
+    new_package >>= 1;
+    StorageType tmp = value;*/
+    /*printf("set index %lld  value %lld  new_package %llu  tmp %llu\n",
+          index, value, new_package, tmp);*/
+    //new_package |= tmp << offset_in_package;
+    /*printf("set index %lld  value %lld  new_package2 %llu  tmp %llu\n",
+          index, value, new_package, tmp);*/
+    int_fast64_t remaining_bits =
+        num_bits_per_package_ - (offset_in_package + item_size_);
+    if (remaining_bits > 0) {
+      tmp = data_[first_package];
+      tmp >>= (num_bits_per_package_ - remaining_bits);
+      tmp <<= (num_bits_per_package_ - remaining_bits);
+      /*printf("set index %lld  value %lld  remaining_bits %lld  tmp %llu\n",
+          index, value, remaining_bits, tmp);*/
+      data_[first_package] = new_package | tmp;
+    } else if (remaining_bits == 0) {
+      /*printf("set index %lld  value %lld  remaining_bits %lld  tmp %llu\n",
+          index, value, remaining_bits, tmp);*/
+      data_[first_package] = new_package;
+    } else {
+      //printf("set: in else case\n");
+      data_[first_package] = new_package;
+      tmp = value;
+      new_package = tmp >> (item_size_ + remaining_bits);
+      tmp = data_[first_package + 1];
+      tmp >>= -remaining_bits;
+      tmp <<= -remaining_bits;
+      data_[first_package + 1] = tmp | new_package;
+    }
+    //printf("current state: %llx\n", data_[0]);
+  }
+ 
+ private:
+  const int_fast64_t num_bits_per_package_ = 8 * sizeof(StorageType);
+  
+  int_fast64_t num_items_;
+  int_fast64_t item_size_;
+  int_fast64_t num_data_packets_;
+  std::vector<StorageType> data_;
+};
+
+}  // namespace core
+}  // namespace falconn
+
+
+#endif

--- a/src/include/falconn/core/bit_packed_vector.h
+++ b/src/include/falconn/core/bit_packed_vector.h
@@ -46,7 +46,7 @@ class BitPackedVector {
   }
 
   // For (potential) performance reasons, get() does no bounds checking.
-  DataType get(IndexType index) {
+  DataType get(IndexType index) const {
     int_fast64_t first_bit = index * item_size_;
     int_fast64_t first_package = first_bit / num_bits_per_package_;
     int_fast64_t offset_in_package =

--- a/src/include/falconn/core/flat_hash_table.h
+++ b/src/include/falconn/core/flat_hash_table.h
@@ -33,7 +33,7 @@ class FlatHashTable {
       }
     }
 
-    FlatHashTable<KeyType>* new_hash_table() {
+    FlatHashTable<KeyType, ValueType, IndexType>* new_hash_table() {
       return new FlatHashTable<KeyType, ValueType, IndexType>(num_buckets_);
     }
 
@@ -85,6 +85,8 @@ class FlatHashTable {
   std::pair<Iterator, Iterator> retrieve(const KeyType& key) {
     IndexType start = bucket_list_[key].first;
     IndexType len = bucket_list_[key].second;
+    //printf("retrieve for key %u\n", key);
+    //printf("  start: %lld  len %lld\n", start, len);
     return std::make_pair(&(indices_[start]), &(indices_[start + len]));
   }
  

--- a/src/include/falconn/core/lsh_table.h
+++ b/src/include/falconn/core/lsh_table.h
@@ -151,7 +151,7 @@ class StaticLSHTable : public BasicLSHTable<LSH, HashTable, StaticLSHTable<
       stats_.average_total_query_time += elapsed_total.count();
     }
 
-    void get_unique_sorted_candidates(const PointType& p,
+    /*void get_unique_sorted_candidates(const PointType& p,
                                       int_fast64_t num_probes,
                                       int_fast64_t max_num_candidates,
                                       std::vector<KeyType>* result) {
@@ -165,7 +165,7 @@ class StaticLSHTable : public BasicLSHTable<LSH, HashTable, StaticLSHTable<
       auto elapsed_total = std::chrono::duration_cast<
           std::chrono::duration<double>>(end_time - start_time);
       stats_.average_total_query_time += elapsed_total.count();
-    }
+    }*/
 
     void reset_query_statistics() {
       stats_num_queries_ = 0;

--- a/src/include/falconn/core/lsh_table.h
+++ b/src/include/falconn/core/lsh_table.h
@@ -4,9 +4,11 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <future>
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "data_storage.h"
@@ -72,16 +74,44 @@ class StaticLSHTable : public BasicLSHTable<LSH, HashTable, StaticLSHTable<
  public:
   StaticLSHTable(LSH* lsh,
                  HashTable* hash_table,
-                 const DataStorageType& points)
+                 const DataStorageType& points,
+                 int_fast32_t num_setup_threads)
       : BasicLSHTable<LSH, HashTable, StaticLSHTable<PointType, KeyType, LSH,
             HashType, HashTable, DataStorageType>>(lsh, hash_table),
         n_(points.size()) {
-    typename LSH::template BatchHash<DataStorageType> bh(*(this->lsh_));
-    std::vector<HashType> table_hashes;
+    if (num_setup_threads < 0) {
+      throw LSHTableError("Number of setup threads cannot be negative.");
+    }
+    if (num_setup_threads == 0) {
+      num_setup_threads = std::max(1u, std::thread::hardware_concurrency());
+    }
+    int l = this->lsh_->get_l();
 
-    for (int_fast32_t ii = 0; ii < this->lsh_->get_l(); ++ii) {
-      bh.batch_hash_single_table(points, ii, &table_hashes);
-      this->hash_table_->add_entries_for_table(table_hashes, ii);
+    num_setup_threads = std::min(l, num_setup_threads);
+    int_fast32_t num_tables_per_thread = l / num_setup_threads;
+    int_fast32_t num_leftover_tables = l % num_setup_threads;
+
+    std::vector<std::future<void>> thread_results;
+    int_fast32_t next_table_range_start = 0;
+
+    for (int_fast32_t ii = 0; ii < num_setup_threads; ++ii) {
+      int_fast32_t next_table_range_end = next_table_range_start
+          + num_tables_per_thread - 1;
+      if (ii < num_leftover_tables) {
+        next_table_range_end += 1;
+      }
+      thread_results.push_back(
+          std::async(std::launch::async,
+                     &StaticLSHTable::setup_table_range,
+                     this,
+                     next_table_range_start,
+                     next_table_range_end,
+                     points));
+      next_table_range_start = next_table_range_end + 1;
+    }
+    
+    for (int_fast32_t ii = 0; ii < num_setup_threads; ++ii) {
+      thread_results[ii].get();
     }
   }
   
@@ -252,6 +282,17 @@ class StaticLSHTable : public BasicLSHTable<LSH, HashTable, StaticLSHTable<
  
  private:
   int_fast64_t n_;
+
+  void setup_table_range(int_fast32_t from,
+                         int_fast32_t to,
+                         const DataStorageType& points) {
+    typename LSH::template BatchHash<DataStorageType> bh(*(this->lsh_));
+    std::vector<HashType> table_hashes;
+    for (int_fast32_t ii = from; ii <= to; ++ii) {
+      bh.batch_hash_single_table(points, ii, &table_hashes);
+      this->hash_table_->add_entries_for_table(table_hashes, ii);
+    }
+  }
 };
 
 

--- a/src/include/falconn/core/math_helpers.h
+++ b/src/include/falconn/core/math_helpers.h
@@ -4,6 +4,25 @@
 namespace falconn {
 namespace core {
 
+int_fast64_t find_next_power_of_two(int_fast64_t x) {
+  int_fast64_t res = 1;
+  while (res < x) {
+    res *= 2;
+  }
+  return res;
+}
+
+int_fast64_t log2ceil(int_fast64_t x) {
+  int_fast64_t res = 0;
+  int_fast64_t cur = 1;
+  while (cur < x) {
+    cur *= 2;
+    res += 1;
+  }
+  return res;
+}
+
+
 template<typename Point>
 struct NormalizationHelper {
   static void normalize(Point*) {

--- a/src/include/falconn/core/nn_query.h
+++ b/src/include/falconn/core/nn_query.h
@@ -42,10 +42,10 @@ class NearestNeighborQuery {
     auto start_time = std::chrono::high_resolution_clock::now();
     stats_num_queries_ += 1; 
     
-    table_query_->get_unique_sorted_candidates(q,
-                                               num_probes,
-                                               max_num_candidates,
-                                               &candidates_);
+    table_query_->get_unique_candidates(q,
+                                        num_probes,
+                                        max_num_candidates,
+                                        &candidates_);
     auto distance_start_time = std::chrono::high_resolution_clock::now();
     
     // TODO: use nullptr for pointer types
@@ -100,10 +100,10 @@ class NearestNeighborQuery {
     std::vector<LSHTableKeyType>& res = *result;
     res.clear();
 
-    table_query_->get_unique_sorted_candidates(q,
-                                               num_probes,
-                                               max_num_candidates,
-                                               &candidates_);
+    table_query_->get_unique_candidates(q,
+                                        num_probes,
+                                        max_num_candidates,
+                                        &candidates_);
 
     heap_.reset();
     heap_.resize(k);
@@ -166,10 +166,10 @@ class NearestNeighborQuery {
     std::vector<LSHTableKeyType>& res = *result;
     res.clear();
 
-    table_query_->get_unique_sorted_candidates(q,
-                                               num_probes,
-                                               max_num_candidates,
-                                               &candidates_);
+    table_query_->get_unique_candidates(q,
+                                        num_probes,
+                                        max_num_candidates,
+                                        &candidates_);
     auto distance_start_time = std::chrono::high_resolution_clock::now();
     
     typename DataStorage::SubsequenceIterator iter =

--- a/src/include/falconn/core/polytope_hash.h
+++ b/src/include/falconn/core/polytope_hash.h
@@ -41,6 +41,15 @@ static inline void compute_k_parameters_for_bits(
   }
 }
 
+static inline int_fast32_t compute_number_of_hash_bits(
+    int_fast32_t rotation_dim,
+    int_fast32_t last_cp_dim,
+    int_fast32_t k) {
+  int_fast32_t log_rotation_dim = log2ceil(rotation_dim);
+  int_fast32_t last_cp_log_dim = log2ceil(last_cp_dim);
+  return (k - 1) * (log_rotation_dim + 1) + last_cp_log_dim + 1;
+}
+
 template <typename ScalarType>
 struct FHTFunction {
   static void apply(ScalarType*, int_fast32_t) {
@@ -212,7 +221,7 @@ class CrossPolytopeHashBase {
   int_fast32_t get_l() const {
     return l_;
   }
-
+  
   void reserve_transformed_vector_memory(TransformedVectorType* tv) const {
     tv->resize(k_ * l_);
     for (int_fast32_t ii = 0; ii < k_ * l_; ++ii) {

--- a/src/include/falconn/core/polytope_hash.h
+++ b/src/include/falconn/core/polytope_hash.h
@@ -17,30 +17,13 @@
 #include "heap.h"
 #include "incremental_sorter.h"
 #include "lsh_function_helpers.h"
+#include "math_helpers.h"
 
 namespace falconn {
 namespace core {
 
 // TODO: move this namespace to a separate file
 namespace cp_hash_helpers {
-
-static int_fast32_t find_next_power_of_two(int_fast32_t x) {
-  int_fast32_t res = 1;
-  while (res < x) {
-    res *= 2;
-  }
-  return res;
-}
-
-static int_fast32_t log2ceil(int_fast32_t x) {
-  int_fast32_t res = 0;
-  int_fast64_t cur = 1;
-  while (cur < x) {
-    cur *= 2;
-    res += 1;
-  }
-  return res;
-}
 
 static inline void compute_k_parameters_for_bits(
     int_fast32_t rotation_dim,
@@ -300,12 +283,12 @@ class CrossPolytopeHashBase {
                         int_fast32_t last_cp_dim,
                         uint_fast64_t seed)
     : rotation_dim_(rotation_dim),
-      log_rotation_dim_(cp_hash_helpers::log2ceil(rotation_dim)),
+      log_rotation_dim_(log2ceil(rotation_dim)),
       k_(k),
       l_(l),
       num_rotations_(num_rotations),
       last_cp_dim_(last_cp_dim),
-      last_cp_log_dim_(cp_hash_helpers::log2ceil(last_cp_dim)),
+      last_cp_log_dim_(log2ceil(last_cp_dim)),
       seed_(seed) {
     if (rotation_dim_ < 1) {
       throw LSHFunctionError("Rotation dimension must be at least 1.");
@@ -738,8 +721,8 @@ class CrossPolytopeHashDense : public CrossPolytopeHashBase<
           CrossPolytopeHashDense<CoordinateType, HashType>,
           Eigen::Matrix<CoordinateType, Eigen::Dynamic, 1, Eigen::ColMajor>,
           CoordinateType,
-          HashType>(cp_hash_helpers::find_next_power_of_two(vector_dim), k, l,
-                    num_rotations, last_cp_dim, seed),
+          HashType>(find_next_power_of_two(vector_dim), k, l, num_rotations,
+              last_cp_dim, seed),
       vector_dim_(vector_dim) {
     if (vector_dim_ < 1) {
       throw LSHFunctionError("Vector dimension must be at least 1.");

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -213,6 +213,30 @@ static const std::array<const char*, 3> kDistanceFunctionStrings = {
 
 
 ///
+/// The supported low-level storage hash tables.
+///
+enum class StorageHashTable {
+  Unknown = 0,
+
+  FlatHashTable = 1,
+
+  BitPackedFlatHashTable = 2,
+
+  STLHashTable = 3,
+
+  LinearProbingHashTable = 4
+};
+
+static const std::array<const char*, 5> kStorageHashTableStrings = {
+    "unknown",
+    "flat_hash_table",
+    "bit_packed_flat_hash_table",
+    "stl_hash_table",
+    "linear_probing_hash_table"
+};
+
+
+///
 /// Contains the parameters for constructing a LSH table wrapper. Not all fields
 /// are necessary for all types of LSH tables.
 ///
@@ -238,6 +262,10 @@ struct LSHConstructionParameters {
   /// Number of hash tables. Required for all the hash families.
   ///
   int_fast32_t l = -1;
+  ///
+  /// Low-level storage hash table.
+  ///
+  StorageHashTable storage_hash_table = StorageHashTable::Unknown;
   ///
   /// Randomness seed.
   ///

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -112,17 +112,6 @@ class LSHNearestNeighborTable {
       std::vector<KeyType>* result) = 0;
   
   ///
-  /// Returns the keys of all candidates in the probing sequence for q.
-  /// Every candidate key occurs only once in the result,
-  /// and the candidate keys are also sorted by their key. This
-  /// can be good for memory locality when the next processing step is a linear
-  /// scan over the resulting candidates.
-  ///
-  virtual void get_unique_sorted_candidates(
-      const PointType& q,
-      std::vector<KeyType>* result) = 0;
- 
-  ///
   /// Resets the query statistics.
   ///
   virtual void reset_query_statistics() = 0;

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -256,6 +256,13 @@ struct LSHConstructionParameters {
   ///
   StorageHashTable storage_hash_table = StorageHashTable::Unknown;
   ///
+  /// Number of threads used to set up the hash table.
+  /// Zero indicates that FALCONN should use the maximum number of available
+  /// hardware threads (or 1 if this number cannot be determined).
+  /// The number of threads used is always at most the number of tables l.
+  ///
+  int_fast32_t num_setup_threads = -1;
+  ///
   /// Randomness seed.
   ///
   uint64_t seed = 409556018;

--- a/src/include/falconn/wrapper/cpp_wrapper_impl.h
+++ b/src/include/falconn/wrapper/cpp_wrapper_impl.h
@@ -382,12 +382,6 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
     query_->get_unique_candidates(q, num_probes_, max_num_candidates_, result);
   }
 
-  void get_unique_sorted_candidates(const PointType& q,
-                                    std::vector<KeyType>* result) {
-    query_->get_unique_sorted_candidates(q, num_probes_, max_num_candidates_,
-                                         result);
-  }
-
   void reset_query_statistics() {
     nn_query_->reset_query_statistics();
   }

--- a/src/include/falconn/wrapper/cpp_wrapper_impl.h
+++ b/src/include/falconn/wrapper/cpp_wrapper_impl.h
@@ -125,8 +125,8 @@ struct ComputeNumberOfHashFunctions<DenseVector<CoordinateType>> {
         throw LSHNNTableSetupError("Vector dimension must be set to determine "
             "the number of dense cross polytope hash functions.");
       }
-      int_fast32_t rotation_dim =
-          core::cp_hash_helpers::find_next_power_of_two(params->dimension);
+      int_fast32_t rotation_dim = core::find_next_power_of_two(
+          params->dimension);
       core::cp_hash_helpers::compute_k_parameters_for_bits(rotation_dim,
           number_of_hash_bits, &(params->k), &(params->last_cp_dimension));
     } else {
@@ -149,7 +149,7 @@ struct ComputeNumberOfHashFunctions<SparseVector<CoordinateType, IndexType>> {
       }
       // TODO: add check here for power-of-two feature hashing dimension
       // (or allow non-power-of-two feature hashing dimension in the CP hash)
-      int_fast32_t rotation_dim = core::cp_hash_helpers::find_next_power_of_two(
+      int_fast32_t rotation_dim = core::find_next_power_of_two(
           params->feature_hashing_dimension);
       core::cp_hash_helpers::compute_k_parameters_for_bits(rotation_dim,
           number_of_hash_bits, &(params->k), &(params->last_cp_dimension));

--- a/src/include/falconn/wrapper/cpp_wrapper_impl.h
+++ b/src/include/falconn/wrapper/cpp_wrapper_impl.h
@@ -1,15 +1,20 @@
 #ifndef __CPP_WRAPPER_IMPL_H__
 #define __CPP_WRAPPER_IMPL_H__
 
+#include <type_traits>
+
+#include "../core/bit_packed_flat_hash_table.h"
 #include "../core/composite_hash_table.h"
 #include "../core/cosine_distance.h"
 #include "../core/data_storage.h"
 #include "../core/euclidean_distance.h"
+#include "../core/flat_hash_table.h"
 #include "../core/hyperplane_hash.h"
 #include "../core/lsh_table.h"
 #include "../core/nn_query.h"
 #include "../core/polytope_hash.h"
 #include "../core/probing_hash_table.h"
+#include "../core/stl_hash_table.h"
 
 namespace falconn {
 namespace wrapper {
@@ -163,6 +168,72 @@ struct ComputeNumberOfHashFunctions<SparseVector<CoordinateType, IndexType>> {
 
 
 template<typename PointType>
+struct ComputeNumberOfHashBits {
+  static int_fast32_t compute(const LSHConstructionParameters&) {
+    static_assert(FalseStruct<PointType>::value, "Point type not supported.");
+    return 0;
+  }
+  template<typename T> struct FalseStruct : std::false_type {};
+};
+
+template<typename CoordinateType>
+struct ComputeNumberOfHashBits<DenseVector<CoordinateType>> {
+  static int_fast32_t compute(const LSHConstructionParameters& params) {
+    if (params.k <= 0) {
+      throw LSHNNTableSetupError("Number of hash functions k must be at least "
+          "1 to determine the number of hash bits.");
+    }
+    if (params.lsh_family == LSHFamily::Hyperplane) {
+      return params.k;
+    } else if (params.lsh_family == LSHFamily::CrossPolytope) {
+      if (params.dimension <= 0) {
+        throw LSHNNTableSetupError("Vector dimension must be set to determine "
+            "the number of dense cross polytope hash bits.");
+      }
+      if (params.last_cp_dimension <= 0) {
+        throw LSHNNTableSetupError("Last cross-polytope dimension must be set "
+            "to determine the number of dense cross polytope hash bits.");
+      }
+      return core::cp_hash_helpers::compute_number_of_hash_bits(
+          params.dimension, params.last_cp_dimension, params.k);
+    } else {
+      throw LSHNNTableSetupError("Cannot compute number of hash bits for "
+          "unknown hash family.");
+    }
+  }
+};
+
+template<typename CoordinateType, typename IndexType>
+struct ComputeNumberOfHashBits<SparseVector<CoordinateType, IndexType>> {
+  static int_fast32_t compute(const LSHConstructionParameters& params) {
+    if (params.k <= 0) {
+      throw LSHNNTableSetupError("Number of hash functions k must be at least "
+          "1 to determine the number of hash bits.");
+    }
+    if (params.lsh_family == LSHFamily::Hyperplane) {
+      return params.k;
+    } else if (params.lsh_family == LSHFamily::CrossPolytope) {
+      if (params.feature_hashing_dimension <= 0) {
+        throw LSHNNTableSetupError("Feature hashing dimension must be set to "
+            "determine the number of dense cross polytope hash bits.");
+      }
+      if (params.last_cp_dimension <= 0) {
+        throw LSHNNTableSetupError("Last cross-polytope dimension must be set "
+            "to determine the number of dense cross polytope hash bits.");
+      }
+      return core::cp_hash_helpers::compute_number_of_hash_bits(
+          params.feature_hashing_dimension, params.last_cp_dimension,
+          params.k);
+    } else {
+      throw LSHNNTableSetupError("Cannot compute number of hash bits for "
+          "unknown hash family.");
+    }
+  }
+};
+
+
+
+template<typename PointType>
 struct GetDefaultParameters {
   static LSHConstructionParameters get(int_fast64_t, int_fast32_t,
       DistanceFunction, bool) {
@@ -237,7 +308,7 @@ typename DistanceType,
 typename DistanceFunction,
 typename LSHTable,
 typename LSHFunction,
-typename HashTable,
+typename HashTableFactory,
 typename CompositeHashTable,
 typename NNQuery,
 typename DataStorage>
@@ -246,7 +317,7 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
   LSHNNTableWrapper(
       std::unique_ptr<LSHFunction> lsh,
       std::unique_ptr<LSHTable> lsh_table,
-      std::unique_ptr<typename HashTable::Factory> hash_table_factory,
+      std::unique_ptr<HashTableFactory> hash_table_factory,
       std::unique_ptr<CompositeHashTable> composite_hash_table,
       std::unique_ptr<typename LSHTable::Query> query,
       std::unique_ptr<NNQuery> nn_query,
@@ -330,7 +401,7 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
  protected:
   std::unique_ptr<LSHFunction> lsh_;
   std::unique_ptr<LSHTable> lsh_table_;
-  std::unique_ptr<typename HashTable::Factory> hash_table_factory_;
+  std::unique_ptr<HashTableFactory> hash_table_factory_;
   std::unique_ptr<CompositeHashTable> composite_hash_table_;
   std::unique_ptr<typename LSHTable::Query> query_;
   std::unique_ptr<NNQuery> nn_query_;
@@ -341,56 +412,250 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
 };
 
 
+
 template<
 typename PointType,
 typename KeyType,
-typename PointSet,
-typename DistanceFunc,
-typename LSH,
-typename HashType>
-std::unique_ptr<LSHNearestNeighborTable<PointType, KeyType>>
-construction_helper(const PointSet& points,
-                    const LSHConstructionParameters& params,
-                    std::unique_ptr<LSH> lsh) {
+typename PointSet>
+class StaticTableFactory {
+ public:
   typedef typename PointTypeTraits<PointType>::ScalarType ScalarType;
 
   typedef typename DataStorageAdapter<PointSet>::template DataStorage<KeyType>
-      DataStorage;
-  std::unique_ptr<DataStorage> data_storage(std::move(
-      DataStorageAdapter<PointSet>::template construct_data_storage<KeyType>(
-          points)));
-  
-  typedef core::StaticLinearProbingHashTable<HashType, KeyType> HashTable;
-  // TODO: should we go to the next prime here?
-  std::unique_ptr<typename HashTable::Factory> factory(
-      new typename HashTable::Factory(2 * data_storage->size()));
-  
-  typedef core::StaticCompositeHashTable<HashType, KeyType, HashTable>
-      CompositeTable;
-  std::unique_ptr<CompositeTable> composite_table(new CompositeTable(
-      params.l, factory.get()));
-  
-  typedef core::StaticLSHTable<PointType, KeyType, LSH, HashType,
-      CompositeTable, DataStorage> LSHTable;
-  std::unique_ptr<LSHTable> lsh_table(new LSHTable(lsh.get(),
-      composite_table.get(), *data_storage));
-  
-  std::unique_ptr<typename LSHTable::Query> query(
-      new typename LSHTable::Query(*lsh_table));
+      DataStorageType;
 
-  typedef core::NearestNeighborQuery<typename LSHTable::Query, PointType,
-      KeyType, PointType, ScalarType, DistanceFunc, DataStorage> NNQuery;
-  std::unique_ptr<NNQuery> nn_query(new NNQuery(query.get(), *data_storage));
 
-  std::unique_ptr<LSHNearestNeighborTable<PointType, KeyType>> result(
-      new LSHNNTableWrapper<PointType, KeyType, ScalarType,
-          DistanceFunc, LSHTable, LSH, HashTable, CompositeTable,
-          NNQuery, DataStorage>(std::move(lsh), std::move(lsh_table),
-              std::move(factory), std::move(composite_table), std::move(query),
-              std::move(nn_query), std::move(data_storage)));
+  StaticTableFactory(const PointSet& points,
+                    const LSHConstructionParameters& params)
+      : points_(points), params_(params) {}
 
-  return std::move(result);
-}
+  std::unique_ptr<LSHNearestNeighborTable<PointType, KeyType>> setup() {
+    if (params_.dimension < 1) {
+      throw LSHNNTableSetupError("Point dimension must be at least 1. Maybe "
+          "you forgot to set the point dimension in the parameter struct?");
+    }
+    if (params_.k < 1) {
+      throw LSHNNTableSetupError("The number of hash functions k must be at "
+          "least 1. Maybe you forgot to set k in the parameter struct?");
+    }
+    if (params_.l < 1) {
+      throw LSHNNTableSetupError("The number of hash tables l must be at "
+          "least 1. Maybe you forgot to set l in the parameter struct?");
+    }
+  
+    data_storage_ = std::move(DataStorageAdapter<PointSet>::template
+        construct_data_storage<KeyType>(points_));
+    
+    ComputeNumberOfHashBits<PointType> helper;
+    num_bits_ = helper.compute(params_);
+    
+    n_ = data_storage_->size();
+    
+    setup0();
+
+    return std::move(table_);
+  }
+
+ private:
+  void setup0() {
+    if (num_bits_ <= 32) {
+      typedef uint32_t HashType;
+      HashType tmp;
+      setup1(std::make_tuple(tmp));
+    } else if (num_bits_ <= 64) {
+      typedef uint64_t HashType;
+      HashType tmp;
+      setup1(std::make_tuple(tmp));
+    } else {
+      throw LSHNNTableSetupError("More than 64 hash bits are currently not "
+          "supported.");
+    }
+  }
+
+  template <typename V>
+  void setup1(V vals) {
+    typedef typename std::tuple_element<kHashTypeIndex, V>::type HashType;
+    
+    if (params_.lsh_family == LSHFamily::Hyperplane) {
+      typedef typename wrapper::PointTypeTraitsInternal<PointType>::template
+          HPHash<HashType> LSH;
+      std::unique_ptr<LSH> lsh(new LSH(params_.dimension, params_.k, params_.l,
+                                       params_.seed ^ 93384688));
+      setup2(std::tuple_cat(vals, std::make_tuple(std::move(lsh))));
+    } else if (params_.lsh_family == LSHFamily::CrossPolytope) {
+      if (params_.num_rotations < 0) {
+        throw LSHNNTableSetupError("The number of pseudo-random rotations for "
+            "the cross polytope hash must be non-negative. Maybe you forgot to "
+            "set num_rotations in the parameter struct?");
+      }
+      if (params_.last_cp_dimension <= 0) {
+        throw LSHNNTableSetupError("The last cross polytope dimension for "
+            "the cross polytope hash must be at least 1. Maybe you forgot to "
+            "set last_cp_dimension in the parameter struct?");
+      }
+
+      // TODO: for sparse vectors, also check feature_hashing_dimension here (it
+      // is checked in the CP hash class, but the error message is less
+      // verbose).
+
+      typedef typename wrapper::PointTypeTraitsInternal<PointType>::template
+          CPHash<HashType> LSH;
+      std::unique_ptr<LSH> lsh(std::move(
+          wrapper::PointTypeTraitsInternal<PointType>::template
+              construct_cp_hash<HashType>(params_)));
+      setup2(std::tuple_cat(vals, std::make_tuple(std::move(lsh))));
+    } else {
+      throw LSHNNTableSetupError("Unknown hash family. Maybe you forgot to set "
+          "the hash family in the parameter struct?");
+    }
+  }
+
+  template <typename V>
+  void setup2(V vals) {
+    if (params_.distance_function == DistanceFunction::NegativeInnerProduct) {
+      typedef typename wrapper::PointTypeTraitsInternal<PointType>::
+          CosineDistance DistanceFunc;
+      DistanceFunc tmp;
+      setup3(std::tuple_cat(std::move(vals), std::make_tuple(tmp)));
+    } else if (params_.distance_function
+        == DistanceFunction::EuclideanSquared) {
+      typedef typename wrapper::PointTypeTraitsInternal<PointType>::
+          EuclideanDistance DistanceFunc;
+      DistanceFunc tmp;
+      setup3(std::tuple_cat(std::move(vals), std::make_tuple(tmp)));
+    } else {
+      throw LSHNNTableSetupError("Unknown distance function. Maybe you forgot "
+          "to set the hash family in the parameter struct?");
+    }
+  }
+  
+  template <typename V>
+  void setup3(V vals) {
+    typedef typename std::tuple_element<kHashTypeIndex, V>::type HashType;
+
+    if (params_.storage_hash_table == StorageHashTable::FlatHashTable) {
+      typedef core::FlatHashTable<HashType> HashTable;
+      std::unique_ptr<typename HashTable::Factory> factory(
+          new typename HashTable::Factory(1 << num_bits_));
+      
+      typedef core::StaticCompositeHashTable<HashType, KeyType, HashTable>
+          CompositeTable;
+      std::unique_ptr<CompositeTable> composite_table(new CompositeTable(
+          params_.l, factory.get()));
+      setup4(std::tuple_cat(std::move(vals),
+             std::make_tuple(std::move(factory)),
+             std::make_tuple(std::move(composite_table))));
+    } else if (params_.storage_hash_table
+        == StorageHashTable::BitPackedFlatHashTable) {
+      typedef core::BitPackedFlatHashTable<HashType> HashTable;
+      std::unique_ptr<typename HashTable::Factory> factory(
+          new typename HashTable::Factory(1 << num_bits_, n_));
+
+      typedef core::StaticCompositeHashTable<HashType, KeyType, HashTable>
+          CompositeTable;
+      std::unique_ptr<CompositeTable> composite_table(new CompositeTable(
+          params_.l, factory.get()));
+      setup4(std::tuple_cat(std::move(vals),
+             std::make_tuple(std::move(factory)),
+             std::make_tuple(std::move(composite_table))));
+    } else if (params_.storage_hash_table == StorageHashTable::STLHashTable) {
+      typedef core::STLHashTable<HashType> HashTable;
+      std::unique_ptr<typename HashTable::Factory> factory(
+          new typename HashTable::Factory());
+      
+      typedef core::StaticCompositeHashTable<HashType, KeyType, HashTable>
+          CompositeTable;
+      std::unique_ptr<CompositeTable> composite_table(new CompositeTable(
+          params_.l, factory.get()));
+      setup4(std::tuple_cat(std::move(vals),
+             std::make_tuple(std::move(factory)),
+             std::make_tuple(std::move(composite_table))));
+    } else if (params_.storage_hash_table
+        == StorageHashTable::LinearProbingHashTable) {
+      typedef core::StaticLinearProbingHashTable<HashType, KeyType> HashTable;
+      std::unique_ptr<typename HashTable::Factory> factory(
+          new typename HashTable::Factory(2 * n_));
+      
+      typedef core::StaticCompositeHashTable<HashType, KeyType, HashTable>
+          CompositeTable;
+      std::unique_ptr<CompositeTable> composite_table(new CompositeTable(
+          params_.l, factory.get()));
+      setup4(std::tuple_cat(std::move(vals),
+             std::make_tuple(std::move(factory)),
+             std::make_tuple(std::move(composite_table))));
+    } else {
+      throw LSHNNTableSetupError("Unknown storage hash table type. Maybe you "
+          "forgot to set the hash table type in the parameter struct?");
+    }
+  }
+
+  template <typename V>
+  void setup4(V vals) {
+    setup_final(std::move(vals));
+  }
+  
+  template <typename V>
+  void setup_final(V vals) {
+    typedef typename std::tuple_element<kHashTypeIndex, V>::type HashType;
+    
+    typedef typename std::tuple_element<kLSHFamilyIndex, V>::type
+        LSHPointerType;
+    typedef typename LSHPointerType::element_type LSHType;
+   
+    typedef typename std::tuple_element<kDistanceFunctionIndex, V>::type
+        DistanceFunctionType;
+    
+    typedef typename std::tuple_element<kHashTableFactoryIndex, V>::type
+        HashTableFactoryPointerType;
+    typedef typename HashTableFactoryPointerType::element_type
+        HashTableFactoryType;
+    
+    typedef typename std::tuple_element<kCompositeHashTableIndex, V>::type
+        CompositeHashTablePointerType;
+    typedef typename CompositeHashTablePointerType::element_type
+        CompositeHashTableType;
+
+    std::unique_ptr<LSHType>& lsh = std::get<kLSHFamilyIndex>(vals);
+    std::unique_ptr<HashTableFactoryType>& factory
+        = std::get<kHashTableFactoryIndex>(vals);
+    std::unique_ptr<CompositeHashTableType>& composite_table
+        = std::get<kCompositeHashTableIndex>(vals);
+    
+    typedef core::StaticLSHTable<PointType, KeyType, LSHType, HashType,
+        CompositeHashTableType, DataStorageType> LSHTableType;
+    std::unique_ptr<LSHTableType> lsh_table(new LSHTableType(lsh.get(),
+        composite_table.get(), *data_storage_));
+    
+    std::unique_ptr<typename LSHTableType::Query> query(
+        new typename LSHTableType::Query(*lsh_table));
+
+    typedef core::NearestNeighborQuery<typename LSHTableType::Query, PointType,
+        KeyType, PointType, ScalarType, DistanceFunctionType,
+        DataStorageType> NNQueryType;
+    std::unique_ptr<NNQueryType> nn_query(new NNQueryType(query.get(),
+                                                          *data_storage_));
+
+    table_.reset(new LSHNNTableWrapper<PointType, KeyType, ScalarType,
+        DistanceFunctionType, LSHTableType, LSHType, HashTableFactoryType,
+        CompositeHashTableType, NNQueryType, DataStorageType>(
+            std::move(lsh), std::move(lsh_table), std::move(factory),
+            std::move(composite_table), std::move(query),
+            std::move(nn_query), std::move(data_storage_)));
+  }
+
+  const static int_fast32_t kHashTypeIndex = 0;
+  const static int_fast32_t kLSHFamilyIndex = 1;
+  const static int_fast32_t kDistanceFunctionIndex = 2;
+  const static int_fast32_t kHashTableFactoryIndex = 3;
+  const static int_fast32_t kCompositeHashTableIndex = 4;
+
+  const PointSet& points_;
+  const LSHConstructionParameters& params_;
+  std::unique_ptr<DataStorageType> data_storage_;
+  int_fast32_t num_bits_;
+  int_fast64_t n_;
+  std::unique_ptr<LSHNearestNeighborTable<PointType, KeyType>> table_ = nullptr;
+};
 
 
 
@@ -407,6 +672,7 @@ void compute_number_of_hash_functions(int_fast32_t number_of_hash_bits,
   wrapper::ComputeNumberOfHashFunctions<PointType>::compute(
       number_of_hash_bits, params);
 }
+
 
 template<typename PointType>
 LSHConstructionParameters get_default_parameters(
@@ -426,93 +692,9 @@ typename PointSet>
 std::unique_ptr<LSHNearestNeighborTable<PointType, KeyType>> construct_table(
     const PointSet& points,
     const LSHConstructionParameters& params) {
-  if (params.dimension < 1) {
-    throw LSHNNTableSetupError("Point dimension must be at least 1. Maybe you "
-        "forgot to set the point dimension in the parameter struct?");
-  }
-  if (params.k < 1) {
-    throw LSHNNTableSetupError("The number of hash functions k must be at "
-        "least 1. Maybe you forgot to set k in the parameter struct?");
-  }
-  if (params.l < 1) {
-    throw LSHNNTableSetupError("The number of hash tables l must be at "
-        "least 1. Maybe you forgot to set l in the parameter struct?");
-  }
-
-  // TODO: can we allow Unknown here, but then allow only to return all the
-  // (unique) candidates?
-  if (params.distance_function != DistanceFunction::NegativeInnerProduct
-   && params.distance_function != DistanceFunction::EuclideanSquared) {
-    throw LSHNNTableSetupError("Unknown distance function. Maybe you forgot to "
-        "set the distance function in the parameter struct?");
-  }
-
-  // TODO: automatically adapt to 64 bit if necessary
-  typedef uint32_t HashType;
-
-  if (params.lsh_family == LSHFamily::Hyperplane) {
-    typedef typename wrapper::PointTypeTraitsInternal<PointType>::template
-        HPHash<HashType> LSH;
-    std::unique_ptr<LSH> lsh(new LSH(params.dimension, params.k, params.l,
-                                     params.seed ^ 93384688));
-    if (params.distance_function == DistanceFunction::NegativeInnerProduct) {
-      typedef typename wrapper::PointTypeTraitsInternal<PointType>::CosineDistance
-	DistanceFunc;
-      return std::move(wrapper::construction_helper<PointType, KeyType,
-		       PointSet, DistanceFunc, LSH, HashType>(points, params,
-							      std::move(lsh)));
-    }
-    else if (params.distance_function == DistanceFunction::EuclideanSquared) {
-      typedef typename wrapper::PointTypeTraitsInternal<PointType>::EuclideanDistance
-	DistanceFunc;
-      return std::move(wrapper::construction_helper<PointType, KeyType,
-		       PointSet, DistanceFunc, LSH, HashType>(points, params,
-							      std::move(lsh)));
-    } else {
-      throw LSHNNTableSetupError("should not have reached here");
-    }
-  } else if (params.lsh_family == LSHFamily::CrossPolytope) {
-    if (params.num_rotations < 0) {
-      throw LSHNNTableSetupError("The number of pseudo-random rotations for "
-          "the cross polytope hash must be non-negative. Maybe you forgot to "
-          "set num_rotations in the parameter struct?");
-    }
-    if (params.last_cp_dimension <= 0) {
-      throw LSHNNTableSetupError("The last cross polytope dimension for "
-          "the cross polytope hash must be at least 1. Maybe you forgot to "
-          "set last_cp_dimension in the parameter struct?");
-    }
-
-    // TODO: for sparse vectors, also check feature_hashing_dimension here (it
-    // is checked in the CP hash class, but the error message is less verbose).
-
-    typedef typename wrapper::PointTypeTraitsInternal<PointType>::template
-        CPHash<HashType> LSH;
-    std::unique_ptr<LSH> lsh(std::move(
-        wrapper::PointTypeTraitsInternal<PointType>::template
-            construct_cp_hash<HashType>(params)));
-    if (params.distance_function == DistanceFunction::NegativeInnerProduct) {
-      typedef typename wrapper::PointTypeTraitsInternal<PointType>::CosineDistance
-	DistanceFunc;
-      return std::move(wrapper::construction_helper<PointType, KeyType,
-		       PointSet, DistanceFunc, LSH, HashType>(points, params,
-							      std::move(lsh)));
-    }
-    else if (params.distance_function == DistanceFunction::EuclideanSquared) {
-      typedef typename wrapper::PointTypeTraitsInternal<PointType>::EuclideanDistance
-	DistanceFunc;
-      return std::move(wrapper::construction_helper<PointType, KeyType,
-		       PointSet, DistanceFunc, LSH, HashType>(points, params,
-							      std::move(lsh)));
-    } else {
-      throw LSHNNTableSetupError("should not have reached here");
-    }
-  } else {
-    throw LSHNNTableSetupError("Unknown hash family. Maybe you forgot to set "
-        "the hash family in the parameter struct?");
-  }
-
-  throw LSHNNTableSetupError("Reached unexpected control flow point.");
+  wrapper::StaticTableFactory<PointType, KeyType, PointSet> factory(points,
+                                                                    params);
+  return std::move(factory.setup());
 }
 
 }  // namespace falconn

--- a/src/python/benchmark/random_benchmark.py
+++ b/src/python/benchmark/random_benchmark.py
@@ -128,8 +128,10 @@ params_hp = falconn.LSHConstructionParameters()
 params_hp.dimension = d
 params_hp.lsh_family = 'hyperplane'
 params_hp.distance_function = 'negative_inner_product'
+params_hp.storage_hash_table = 'flat_hash_table'
 params_hp.k = 19
 params_hp.l = 10
+params_hp.num_setup_threads = 0
 params_hp.seed = seed ^ 833840234
 
 print('Hyperplane hash\n')
@@ -155,8 +157,10 @@ params_cp = falconn.LSHConstructionParameters()
 params_cp.dimension = d
 params_cp.lsh_family = 'cross_polytope'
 params_cp.distance_function = 'negative_inner_product'
+params_cp.storage_hash_table = 'flat_hash_table'
 params_cp.k = 3
 params_cp.l = 10
+params_cp.num_setup_threads = 0
 params_cp.last_cp_dimension = 16
 params_cp.num_rotations = 3
 params_cp.seed = seed ^ 833840234

--- a/src/python/test/module_test.py
+++ b/src/python/test/module_test.py
@@ -1,0 +1,123 @@
+import falconn
+import numpy as np
+
+def test_lsh_index_positive():
+  n = 1000
+  d = 128
+  p = falconn.get_default_parameters(n, d)
+  t = falconn.LSHIndex(p)
+  dataset = np.random.randn(n, d).astype(np.float32)
+  t.fit(dataset)
+  u = np.random.randn(d).astype(np.float32)
+  t.find_k_nearest_neighbors(u, 10)
+  t.find_near_neighbors(u, 10.0)
+  t.find_nearest_neighbor(u)
+  t.get_candidates_with_duplicates(u)
+  t.get_max_num_candidates()
+  t.get_num_probes()
+  t.get_query_statistics()
+  t.get_unique_candidates(u)
+  t.get_unique_sorted_candidates(u)
+  t.reset_query_statistics()
+  t.set_max_num_candidates(100)
+  t.set_num_probes(10)
+
+def test_lsh_index_negative():
+  n = 1000
+  d = 128
+  p = falconn.get_default_parameters(n, d)
+  t = falconn.LSHIndex(p)
+  try:
+    t.find_nearest_neighbor(np.random.randn(d))
+    assert False
+  except RuntimeError:
+    pass
+  try:
+    dataset = [[1.0, 2.0], [3.0, 4.0]]
+    t.fit(dataset)
+    assert False
+  except TypeError:
+    pass
+  try:
+    dataset = np.random.randn(n, d).astype(np.int32)
+    t.fit(dataset)
+    assert False
+  except ValueError:
+    pass
+  try:
+    dataset = np.random.randn(10, 10, 10)
+    t.fit(dataset)
+    assert False
+  except ValueError:
+    pass
+  dataset = np.random.randn(n, d).astype(np.float32)
+  t.fit(dataset)
+  dataset = np.random.randn(n, d).astype(np.float64)
+  t.fit(dataset)
+  u = np.random.randn(d).astype(np.float64)
+  
+  try:
+    t.find_k_nearest_neighbors(u, 0.5)
+    assert False
+  except TypeError:
+    pass
+
+  try:
+    t.find_k_nearest_neighbors(u, -1)
+    assert False
+  except ValueError:
+    pass
+  
+  t.find_near_neighbors(u, -1)
+  
+  try:
+    t.set_max_num_candidates(0.5)
+    assert False
+  except TypeError:
+    pass
+  try:
+    t.set_max_num_candidates(-10)
+    assert False
+  except ValueError:
+    pass
+  t.set_num_probes(t._params.l)
+  try:
+    t.set_num_probes(t._params.l - 1)
+    assert False
+  except ValueError:
+    pass
+  try:
+    t.set_num_probes(1000.1)
+    assert False
+  except TypeError:
+    pass
+
+  def check_check_query(f):
+    try:
+      f(u.astype(np.float32))
+      assert False
+    except ValueError:
+      pass
+    try:
+      f([0.0] * d)
+      assert False
+    except TypeError:
+      pass
+    try:
+      f(u[:d-1])
+      assert False
+    except ValueError:
+      pass
+    try:
+      f(np.random.randn(d, d))
+      assert False
+    except ValueError:
+      pass
+
+  check_check_query(lambda u: t.find_k_nearest_neighbors(u, 10))
+  check_check_query(lambda u: t.find_near_neighbors(u, 0.5))
+  check_check_query(lambda u: t.find_nearest_neighbor(u))
+  check_check_query(lambda u: t.get_candidates_with_duplicates(u))
+  check_check_query(lambda u: t.get_unique_candidates(u))
+  check_check_query(lambda u: t.get_unique_sorted_candidates(u))
+  t.find_near_neighbors(u, 0.0)

--- a/src/python/test/wrapper_test.py
+++ b/src/python/test/wrapper_test.py
@@ -1,8 +1,11 @@
+import sys
+sys.path.append('python_swig')
+
 import falconn
 import numpy as np
 
 def test_number_of_hash_functions():
-  params = falconn._internal.LSHConstructionParameters()
+  params = falconn.LSHConstructionParameters()
   
   params.lsh_family = 'hyperplane'
   params.dimension = 10
@@ -36,129 +39,10 @@ def test_get_default_parameters():
   params = falconn.get_default_parameters(n, dim, dist_func, True)
   assert params.l == 10
   assert params.lsh_family == 'cross_polytope'
+  assert params.storage_hash_table == 'bit_packed_flat_hash_table'
+  assert params.num_setup_threads == 0
   assert params.k == 2
   assert params.dimension == dim
   assert params.distance_function == dist_func
   assert params.num_rotations == 1
   assert params.last_cp_dimension == 64
-
-def test_lsh_index_positive():
-  n = 1000
-  d = 128
-  p = falconn.get_default_parameters(n, d)
-  t = falconn.LSHIndex(p)
-  dataset = np.random.randn(n, d).astype(np.float32)
-  t.fit(dataset)
-  u = np.random.randn(d).astype(np.float32)
-  t.find_k_nearest_neighbors(u, 10)
-  t.find_near_neighbors(u, 10.0)
-  t.find_nearest_neighbor(u)
-  t.get_candidates_with_duplicates(u)
-  t.get_max_num_candidates()
-  t.get_num_probes()
-  t.get_query_statistics()
-  t.get_unique_candidates(u)
-  t.get_unique_sorted_candidates(u)
-  t.reset_query_statistics()
-  t.set_max_num_candidates(100)
-  t.set_num_probes(10)
-
-def test_lsh_index_negative():
-  n = 1000
-  d = 128
-  p = falconn.get_default_parameters(n, d)
-  t = falconn.LSHIndex(p)
-  try:
-    t.find_nearest_neighbor(np.random.randn(d))
-    assert False
-  except RuntimeError:
-    pass
-  try:
-    dataset = [[1.0, 2.0], [3.0, 4.0]]
-    t.fit(dataset)
-    assert False
-  except TypeError:
-    pass
-  try:
-    dataset = np.random.randn(n, d).astype(np.int32)
-    t.fit(dataset)
-    assert False
-  except ValueError:
-    pass
-  try:
-    dataset = np.random.randn(10, 10, 10)
-    t.fit(dataset)
-    assert False
-  except ValueError:
-    pass
-  dataset = np.random.randn(n, d).astype(np.float32)
-  t.fit(dataset)
-  dataset = np.random.randn(n, d).astype(np.float64)
-  t.fit(dataset)
-  u = np.random.randn(d).astype(np.float64)
-  
-  try:
-    t.find_k_nearest_neighbors(u, 0.5)
-    assert False
-  except TypeError:
-    pass
-
-  try:
-    t.find_k_nearest_neighbors(u, -1)
-    assert False
-  except ValueError:
-    pass
-  
-  t.find_near_neighbors(u, -1)
-  
-  try:
-    t.set_max_num_candidates(0.5)
-    assert False
-  except TypeError:
-    pass
-  try:
-    t.set_max_num_candidates(-10)
-    assert False
-  except ValueError:
-    pass
-  t.set_num_probes(t._params.l)
-  try:
-    t.set_num_probes(t._params.l - 1)
-    assert False
-  except ValueError:
-    pass
-  try:
-    t.set_num_probes(1000.1)
-    assert False
-  except TypeError:
-    pass
-
-  def check_check_query(f):
-    try:
-      f(u.astype(np.float32))
-      assert False
-    except ValueError:
-      pass
-    try:
-      f([0.0] * d)
-      assert False
-    except TypeError:
-      pass
-    try:
-      f(u[:d-1])
-      assert False
-    except ValueError:
-      pass
-    try:
-      f(np.random.randn(d, d))
-      assert False
-    except ValueError:
-      pass
-
-  check_check_query(lambda u: t.find_k_nearest_neighbors(u, 10))
-  check_check_query(lambda u: t.find_near_neighbors(u, 0.5))
-  check_check_query(lambda u: t.find_nearest_neighbor(u))
-  check_check_query(lambda u: t.get_candidates_with_duplicates(u))
-  check_check_query(lambda u: t.get_unique_candidates(u))
-  check_check_query(lambda u: t.get_unique_sorted_candidates(u))
-  t.find_near_neighbors(u, 0.0)

--- a/src/python/wrapper/falconn.i
+++ b/src/python/wrapper/falconn.i
@@ -30,6 +30,7 @@ namespace std {
 %ignore cpp_to_python_construction_parameters;
 %ignore lsh_family_from_string;
 %ignore distance_function_from_string;
+%ignore storage_hash_table_from_string;
 %rename(CppLSHConstructionParameters) falconn::LSHConstructionParameters;
 
 %exception {

--- a/src/test/bit_packed_flat_hash_table_test.cc
+++ b/src/test/bit_packed_flat_hash_table_test.cc
@@ -43,3 +43,10 @@ TEST(BitPackedFlatHashTableTest, RetrieveTest3) {
     ft::run_retrieve_test_4(&table, cur_seed);
   }
 }
+
+TEST(BitPackedFlatHashTableTest, RetrieveTest4) {
+  int num_buckets = 10;
+  int num_items = 3;
+  BitPackedFlatHashTable<uint32_t> table(num_buckets, num_items);
+  ft::run_retrieve_test_5(&table);
+}

--- a/src/test/bit_packed_flat_hash_table_test.cc
+++ b/src/test/bit_packed_flat_hash_table_test.cc
@@ -1,4 +1,4 @@
-#include "falconn/core/flat_hash_table.h"
+#include "falconn/core/bit_packed_flat_hash_table.h"
 
 #include <utility>
 #include <vector>
@@ -10,26 +10,27 @@
 namespace fc = falconn::core;
 namespace ft = falconn::test;
 
-using fc::FlatHashTable;
-using std::pair;
-using std::vector;
+using fc::BitPackedFlatHashTable;
 
-TEST(FlatHashTableTest, RetrieveTest1) {
+TEST(BitPackedFlatHashTableTest, RetrieveTest1) {
   int num_buckets = 10;
-  FlatHashTable<uint32_t> table(num_buckets);
+  int num_items = 8;
+  BitPackedFlatHashTable<uint32_t> table(num_buckets, num_items);
   ft::run_retrieve_test_1(&table);
 }
 
 // test 2 does not apply because the test uses large key ranges
 
-TEST(FlatHashTableTest, RetrieveTest2) {
+TEST(BitPackedFlatHashTableTest, RetrieveTest2) {
   int num_buckets = 8;
-  FlatHashTable<uint32_t> table(num_buckets);
+  int num_items = 9;
+  BitPackedFlatHashTable<uint32_t> table(num_buckets, num_items);
   ft::run_retrieve_test_3(&table);
 }
   
-TEST(FlatHashTableTest, RetrieveTest3) {
+TEST(BitPackedFlatHashTableTest, RetrieveTest3) {
   int num_buckets = 64;
+  int num_items = 1000;
   int num_trials = 100;
   uint64_t seed = 302342321;
   std::mt19937_64 gen(seed);
@@ -37,7 +38,7 @@ TEST(FlatHashTableTest, RetrieveTest3) {
       std::numeric_limits<uint64_t>::max());
 
   for (int ii = 0; ii < num_trials; ++ii) {
-    FlatHashTable<uint32_t> table(num_buckets);
+    BitPackedFlatHashTable<uint32_t> table(num_buckets, num_items);
     uint64_t cur_seed = dis(gen);
     ft::run_retrieve_test_4(&table, cur_seed);
   }

--- a/src/test/bit_packed_vector_test.cc
+++ b/src/test/bit_packed_vector_test.cc
@@ -1,0 +1,88 @@
+#include "falconn/core/bit_packed_vector.h"
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace fc = falconn::core;
+
+using fc::BitPackedVector;
+
+TEST(BitPackedVectorTest, SimpleTest1) {
+  int size = 4;
+  BitPackedVector<int_fast64_t> v(size, 3);
+
+  for (int ii = 0; ii < size; ++ii) {
+    v.set(ii, ii);
+  }
+  for (int ii = 0; ii < size; ++ii) {
+    EXPECT_EQ(ii, v.get(ii));
+  }
+}
+
+
+TEST(BitPackedVectorTest, SimpleTest2) {
+  int num_bits = 10;
+  int size = 1 << num_bits;
+  BitPackedVector<int_fast64_t> v(size, num_bits);
+
+  for (int ii = 0; ii < size; ++ii) {
+    v.set(ii, ii);
+  }
+  for (int ii = 0; ii < size; ++ii) {
+    EXPECT_EQ(ii, v.get(ii));
+  }
+}
+
+
+TEST(BitPackedVectorTest, RandomTest1) {
+  int_fast64_t num_bits = 30;
+  int size = 1000000;
+  BitPackedVector<int_fast64_t> v(size, num_bits);
+  std::vector<int_fast64_t> ref(size);
+
+  int_fast64_t maxint = 1 << num_bits;
+  std::mt19937_64 gen(4565729829);
+  std::uniform_int_distribution<int_fast64_t> dis(0, maxint - 1);
+
+  for (int ii = 0; ii < size; ++ii) {
+    int_fast64_t cur = dis(gen);
+    v.set(ii, cur);
+    ref[ii] = cur;
+  }
+
+  for (int ii = 0; ii < size; ++ii) {
+    EXPECT_EQ(ref[ii], v.get(ii));
+  }
+}
+
+
+TEST(BitPackedVectorTest, ExhaustiveTest1) {
+  int_fast64_t num_bits = 2;
+  int_fast64_t maxint = 1 << num_bits;
+  int_fast64_t size = 4;
+
+  BitPackedVector<int_fast64_t> v(size, num_bits);
+
+  for (int ii = 0; ii < maxint; ++ii) {
+    for (int jj = 0; jj < maxint; ++jj) {
+      for (int kk = 0; kk < maxint; ++kk) {
+        for (int ll = 0; ll < maxint; ++ll) {
+          v.set(0, ii);
+          v.set(1, jj);
+          v.set(2, kk);
+          v.set(3, ll);
+
+          //printf("%d %d %d %d\n", ii, jj, kk, ll);
+
+          EXPECT_EQ(ii, v.get(0));
+          EXPECT_EQ(jj, v.get(1));
+          EXPECT_EQ(kk, v.get(2));
+          EXPECT_EQ(ll, v.get(3));
+        }
+      }
+    }
+  }
+}

--- a/src/test/cpp_wrapper_test.cc
+++ b/src/test/cpp_wrapper_test.cc
@@ -15,6 +15,7 @@ using falconn::LSHFamily;
 using falconn::LSHNearestNeighborTable;
 using falconn::get_default_parameters;
 using falconn::SparseVector;
+using falconn::StorageHashTable;
 using std::make_pair;
 using std::unique_ptr;
 using std::vector;
@@ -26,6 +27,7 @@ TEST(WrapperTest, DenseHPTest1) {
   params.dimension = dim;
   params.lsh_family = LSHFamily::Hyperplane;
   params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
   params.k = 2;
   params.l = 4;
 
@@ -76,6 +78,7 @@ TEST(WrapperTest, DenseCPTest1) {
   params.dimension = dim;
   params.lsh_family = LSHFamily::CrossPolytope;
   params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
   params.k = 2;
   params.l = 8;
   params.last_cp_dimension = dim;
@@ -128,6 +131,7 @@ TEST(WrapperTest, SparseHPTest1) {
   params.dimension = dim;
   params.lsh_family = LSHFamily::Hyperplane;
   params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
   params.k = 2;
   params.l = 4;
 
@@ -167,6 +171,7 @@ TEST(WrapperTest, SparseCPTest1) {
   params.dimension = dim;
   params.lsh_family = LSHFamily::CrossPolytope;
   params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
   params.k = 2;
   params.l = 4;
   params.feature_hashing_dimension = 8;
@@ -195,6 +200,8 @@ TEST(WrapperTest, SparseCPTest1) {
   int32_t res3 = table->find_nearest_neighbor(p3);
   EXPECT_EQ(2, res3);
 
+  //printf("LAST QUERY\n");
+   
   Point p4;
   p4.push_back(make_pair(7, 1.0));
   int32_t res4 = table->find_nearest_neighbor(p4);

--- a/src/test/cpp_wrapper_test.cc
+++ b/src/test/cpp_wrapper_test.cc
@@ -20,17 +20,11 @@ using std::make_pair;
 using std::unique_ptr;
 using std::vector;
 
-TEST(WrapperTest, DenseHPTest1) {
-  int dim = 4;
+// Point dimension is 4
+void basic_test_dense_1(const LSHConstructionParameters& params) {
   typedef DenseVector<float> Point;
-  LSHConstructionParameters params;
-  params.dimension = dim;
-  params.lsh_family = LSHFamily::Hyperplane;
-  params.distance_function = DistanceFunction::NegativeInnerProduct;
-  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
-  params.k = 2;
-  params.l = 4;
-
+  int dim = 4;
+  
   Point p1(dim);
   p1[0] = 1.0;
   p1[1] = 0.0;
@@ -71,9 +65,54 @@ TEST(WrapperTest, DenseHPTest1) {
 }
 
 
+void basic_test_sparse_1(const LSHConstructionParameters& params) {
+  typedef SparseVector<float> Point;
+  Point p1;
+  p1.push_back(make_pair(24, 1.0));
+  Point p2;
+  p2.push_back(make_pair(7, 0.8));
+  p2.push_back(make_pair(24, 0.6));
+  Point p3;
+  p3.push_back(make_pair(50, 1.0));
+  vector<Point> points;
+  points.push_back(p1);
+  points.push_back(p2);
+  points.push_back(p3);
+  
+  unique_ptr<LSHNearestNeighborTable<Point>> table(std::move(
+      construct_table<Point>(points, params)));
+
+  int32_t res1 = table->find_nearest_neighbor(p1);
+  EXPECT_EQ(0, res1);
+  int32_t res2 = table->find_nearest_neighbor(p2);
+  EXPECT_EQ(1, res2);
+  int32_t res3 = table->find_nearest_neighbor(p3);
+  EXPECT_EQ(2, res3);
+
+  Point p4;
+  p4.push_back(make_pair(7, 1.0));
+  int32_t res4 = table->find_nearest_neighbor(p4);
+  EXPECT_EQ(1, res4);
+}
+
+
+
+TEST(WrapperTest, DenseHPTest1) {
+  int dim = 4;
+  LSHConstructionParameters params;
+  params.dimension = dim;
+  params.lsh_family = LSHFamily::Hyperplane;
+  params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
+  params.k = 2;
+  params.l = 4;
+  
+  basic_test_dense_1(params);
+}
+
+
 TEST(WrapperTest, DenseCPTest1) {
   int dim = 4;
-  typedef DenseVector<float> Point;
   LSHConstructionParameters params;
   params.dimension = dim;
   params.lsh_family = LSHFamily::CrossPolytope;
@@ -84,49 +123,12 @@ TEST(WrapperTest, DenseCPTest1) {
   params.last_cp_dimension = dim;
   params.num_rotations = 3;
 
-  Point p1(dim);
-  p1[0] = 1.0;
-  p1[1] = 0.0;
-  p1[2] = 0.0;
-  p1[3] = 0.0;
-  Point p2(dim);
-  p2[0] = 0.6;
-  p2[1] = 0.8;
-  p2[2] = 0.0;
-  p2[3] = 0.0;
-  Point p3(dim);
-  p3[0] = 0.0;
-  p3[1] = 0.0;
-  p3[2] = 1.0;
-  p3[3] = 0.0;
-  vector<Point> points;
-  points.push_back(p1);
-  points.push_back(p2);
-  points.push_back(p3);
-  
-  unique_ptr<LSHNearestNeighborTable<Point>> table(std::move(
-      construct_table<Point>(points, params)));
-
-  int32_t res1 = table->find_nearest_neighbor(p1);
-  EXPECT_EQ(0, res1);
-  int32_t res2 = table->find_nearest_neighbor(p2);
-  EXPECT_EQ(1, res2);
-  int32_t res3 = table->find_nearest_neighbor(p3);
-  EXPECT_EQ(2, res3);
-
-  Point p4(dim);
-  p4[0] = 0.0;
-  p4[1] = 1.0;
-  p4[2] = 0.0;
-  p4[3] = 0.0;
-  int32_t res4 = table->find_nearest_neighbor(p4);
-  EXPECT_EQ(1, res4);
+  basic_test_dense_1(params);
 }
 
 
 TEST(WrapperTest, SparseHPTest1) {
   int dim = 100;
-  typedef SparseVector<float> Point;
   LSHConstructionParameters params;
   params.dimension = dim;
   params.lsh_family = LSHFamily::Hyperplane;
@@ -135,38 +137,12 @@ TEST(WrapperTest, SparseHPTest1) {
   params.k = 2;
   params.l = 4;
 
-  Point p1;
-  p1.push_back(make_pair(24, 1.0));
-  Point p2;
-  p2.push_back(make_pair(7, 0.8));
-  p2.push_back(make_pair(24, 0.6));
-  Point p3;
-  p3.push_back(make_pair(50, 1.0));
-  vector<Point> points;
-  points.push_back(p1);
-  points.push_back(p2);
-  points.push_back(p3);
-  
-  unique_ptr<LSHNearestNeighborTable<Point>> table(std::move(
-      construct_table<Point>(points, params)));
-
-  int32_t res1 = table->find_nearest_neighbor(p1);
-  EXPECT_EQ(0, res1);
-  int32_t res2 = table->find_nearest_neighbor(p2);
-  EXPECT_EQ(1, res2);
-  int32_t res3 = table->find_nearest_neighbor(p3);
-  EXPECT_EQ(2, res3);
-
-  Point p4;
-  p4.push_back(make_pair(7, 1.0));
-  int32_t res4 = table->find_nearest_neighbor(p4);
-  EXPECT_EQ(1, res4);
+  basic_test_sparse_1(params);
 }
 
 
 TEST(WrapperTest, SparseCPTest1) {
   int dim = 100;
-  typedef SparseVector<float> Point;
   LSHConstructionParameters params;
   params.dimension = dim;
   params.lsh_family = LSHFamily::CrossPolytope;
@@ -177,36 +153,66 @@ TEST(WrapperTest, SparseCPTest1) {
   params.feature_hashing_dimension = 8;
   params.last_cp_dimension = 8;
   params.num_rotations = 3;
-
-  Point p1;
-  p1.push_back(make_pair(24, 1.0));
-  Point p2;
-  p2.push_back(make_pair(7, 0.8));
-  p2.push_back(make_pair(24, 0.6));
-  Point p3;
-  p3.push_back(make_pair(50, 1.0));
-  vector<Point> points;
-  points.push_back(p1);
-  points.push_back(p2);
-  points.push_back(p3);
   
-  unique_ptr<LSHNearestNeighborTable<Point>> table(std::move(
-      construct_table<Point>(points, params)));
-
-  int32_t res1 = table->find_nearest_neighbor(p1);
-  EXPECT_EQ(0, res1);
-  int32_t res2 = table->find_nearest_neighbor(p2);
-  EXPECT_EQ(1, res2);
-  int32_t res3 = table->find_nearest_neighbor(p3);
-  EXPECT_EQ(2, res3);
-
-  //printf("LAST QUERY\n");
-   
-  Point p4;
-  p4.push_back(make_pair(7, 1.0));
-  int32_t res4 = table->find_nearest_neighbor(p4);
-  EXPECT_EQ(1, res4);
+  basic_test_sparse_1(params);
 }
+
+
+TEST(WrapperTest, FlatHashTableTest1) {
+  int dim = 4;
+  LSHConstructionParameters params;
+  params.dimension = dim;
+  params.lsh_family = LSHFamily::Hyperplane;
+  params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::FlatHashTable;
+  params.k = 2;
+  params.l = 4;
+  
+  basic_test_dense_1(params);
+}
+
+
+TEST(WrapperTest, BitPackedFlatHashTableTest1) {
+  int dim = 4;
+  LSHConstructionParameters params;
+  params.dimension = dim;
+  params.lsh_family = LSHFamily::Hyperplane;
+  params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
+  params.k = 2;
+  params.l = 4;
+  
+  basic_test_dense_1(params);
+}
+
+
+TEST(WrapperTest, STLHashTableTest1) {
+  int dim = 4;
+  LSHConstructionParameters params;
+  params.dimension = dim;
+  params.lsh_family = LSHFamily::Hyperplane;
+  params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::STLHashTable;
+  params.k = 2;
+  params.l = 4;
+  
+  basic_test_dense_1(params);
+}
+
+
+TEST(WrapperTest, LinearProbingHashTableTest1) {
+  int dim = 4;
+  LSHConstructionParameters params;
+  params.dimension = dim;
+  params.lsh_family = LSHFamily::Hyperplane;
+  params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::LinearProbingHashTable;
+  params.k = 2;
+  params.l = 4;
+  
+  basic_test_dense_1(params);
+}
+
 
 TEST(WrapperTest, ComputeNumberOfHashFunctionsTest) {
   typedef DenseVector<float> VecDense;

--- a/src/test/cpp_wrapper_test.cc
+++ b/src/test/cpp_wrapper_test.cc
@@ -106,6 +106,7 @@ TEST(WrapperTest, DenseHPTest1) {
   params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
   params.k = 2;
   params.l = 4;
+  params.num_setup_threads = 0;
   
   basic_test_dense_1(params);
 }
@@ -122,6 +123,7 @@ TEST(WrapperTest, DenseCPTest1) {
   params.l = 8;
   params.last_cp_dimension = dim;
   params.num_rotations = 3;
+  params.num_setup_threads = 0;
 
   basic_test_dense_1(params);
 }
@@ -136,6 +138,7 @@ TEST(WrapperTest, SparseHPTest1) {
   params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
   params.k = 2;
   params.l = 4;
+  params.num_setup_threads = 0;
 
   basic_test_sparse_1(params);
 }
@@ -153,6 +156,7 @@ TEST(WrapperTest, SparseCPTest1) {
   params.feature_hashing_dimension = 8;
   params.last_cp_dimension = 8;
   params.num_rotations = 3;
+  params.num_setup_threads = 0;
   
   basic_test_sparse_1(params);
 }
@@ -167,6 +171,7 @@ TEST(WrapperTest, FlatHashTableTest1) {
   params.storage_hash_table = StorageHashTable::FlatHashTable;
   params.k = 2;
   params.l = 4;
+  params.num_setup_threads = 0;
   
   basic_test_dense_1(params);
 }
@@ -181,6 +186,7 @@ TEST(WrapperTest, BitPackedFlatHashTableTest1) {
   params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
   params.k = 2;
   params.l = 4;
+  params.num_setup_threads = 0;
   
   basic_test_dense_1(params);
 }
@@ -195,6 +201,7 @@ TEST(WrapperTest, STLHashTableTest1) {
   params.storage_hash_table = StorageHashTable::STLHashTable;
   params.k = 2;
   params.l = 4;
+  params.num_setup_threads = 0;
   
   basic_test_dense_1(params);
 }
@@ -209,6 +216,7 @@ TEST(WrapperTest, LinearProbingHashTableTest1) {
   params.storage_hash_table = StorageHashTable::LinearProbingHashTable;
   params.k = 2;
   params.l = 4;
+  params.num_setup_threads = 0;
   
   basic_test_dense_1(params);
 }
@@ -256,6 +264,9 @@ TEST(WrapperTest, GetDefaultParametersTest1) {
   EXPECT_EQ(LSHFamily::CrossPolytope, params.lsh_family);
   EXPECT_EQ(3, params.k);
   EXPECT_EQ(2, params.last_cp_dimension);
+  EXPECT_EQ(StorageHashTable::BitPackedFlatHashTable,
+      params.storage_hash_table);
+  EXPECT_EQ(0, params.num_setup_threads);
 }
   
 TEST(WrapperTest, GetDefaultParametersTest2) {
@@ -266,4 +277,7 @@ TEST(WrapperTest, GetDefaultParametersTest2) {
   
   EXPECT_EQ(2, params.num_rotations);
   EXPECT_EQ(1024, params.feature_hashing_dimension);
+  EXPECT_EQ(0, params.num_setup_threads);
+  EXPECT_EQ(StorageHashTable::BitPackedFlatHashTable,
+      params.storage_hash_table);
 }

--- a/src/test/flat_hash_table_test.cc
+++ b/src/test/flat_hash_table_test.cc
@@ -42,3 +42,9 @@ TEST(FlatHashTableTest, RetrieveTest3) {
     ft::run_retrieve_test_4(&table, cur_seed);
   }
 }
+
+TEST(FlatHashTableTest, RetrieveTest4) {
+  int num_buckets = 10;
+  FlatHashTable<uint32_t> table(num_buckets);
+  ft::run_retrieve_test_5(&table);
+}

--- a/src/test/nn_query_test.cc
+++ b/src/test/nn_query_test.cc
@@ -85,7 +85,7 @@ TEST(NNQueryTest, DenseTest1) {
                          uint32_t,
                          CompositeTableType>
           LSHTableType;
-  LSHTableType lsh_table(&lsh_object, &hash_table, points);
+  LSHTableType lsh_table(&lsh_object, &hash_table, points, 1);
   LSHTableType::Query query(lsh_table);
   NearestNeighborQuery<LSHTableType::Query, DenseVector, int32_t, DenseVector,
                        float, CosineDistanceDense<float>, ArrayDataStorageType>
@@ -155,7 +155,7 @@ TEST(NNQueryTest, SparseTest1) {
                          uint32_t,
                          CompositeTableType>
           LSHTableType;
-  LSHTableType lsh_table(&lsh_object, &hash_table, points);
+  LSHTableType lsh_table(&lsh_object, &hash_table, points, 1);
   LSHTableType::Query query(lsh_table);
   NearestNeighborQuery<LSHTableType::Query, SparseVector, int32_t, SparseVector,
                        float, CosineDistanceSparse<float>, ArrayDataStorageType>
@@ -209,7 +209,7 @@ TEST(NNQueryTest, MultiprobeTest1) {
                          uint32_t,
                          CompositeTableType>
           LSHTableType;
-  LSHTableType lsh_table(&lsh_object, &hash_table, points);
+  LSHTableType lsh_table(&lsh_object, &hash_table, points, 1);
   LSHTableType::Query query(lsh_table);
   NearestNeighborQuery<LSHTableType::Query, DenseVector, int32_t, DenseVector,
                        float, CosineDistanceDense<float>, ArrayDataStorageType>
@@ -271,7 +271,7 @@ TEST(NNQueryTest, FindNearNeighborsTest1) {
                          uint32_t,
                          CompositeTableType>
           LSHTableType;
-  LSHTableType lsh_table(&lsh_object, &hash_table, points);
+  LSHTableType lsh_table(&lsh_object, &hash_table, points, 1);
   LSHTableType::Query query(lsh_table);
   NearestNeighborQuery<LSHTableType::Query, DenseVector, int32_t, DenseVector,
                        float, CosineDistanceDense<float>, ArrayDataStorageType>
@@ -355,7 +355,7 @@ TEST(NNQueryTest, KNNTest1) {
                          uint32_t,
                          CompositeTableType>
           LSHTableType;
-  LSHTableType lsh_table(&lsh_object, &hash_table, points);
+  LSHTableType lsh_table(&lsh_object, &hash_table, points, 1);
   LSHTableType::Query query(lsh_table);
   NearestNeighborQuery<LSHTableType::Query, DenseVector, int32_t, DenseVector,
                        float, CosineDistanceDense<float>, ArrayDataStorageType>

--- a/src/test/polytope_hash_test.cc
+++ b/src/test/polytope_hash_test.cc
@@ -16,7 +16,7 @@ namespace ft = falconn::test;
 using fc::ArrayDataStorage;
 using fc::cp_hash_helpers::compute_k_parameters_for_bits;
 using fc::cp_hash_helpers::FHTHelper;
-using fc::cp_hash_helpers::log2ceil;
+using fc::log2ceil;
 using fc::CrossPolytopeHashDense;
 using fc::CrossPolytopeHashSparse;
 using ft::count_bits;

--- a/src/test/probing_hash_table_test.cc
+++ b/src/test/probing_hash_table_test.cc
@@ -41,6 +41,27 @@ TEST(ProbingHashTableTest, StaticLinearProbingRetrieveTest4) {
   ft::run_retrieve_test_2(&table);
 }
 
+TEST(ProbingHashTableTest, StaticLinearProbingRetrieveTest5) {
+  int table_size = 9;
+  StaticLinearProbingHashTable<uint32_t> table(table_size);
+  ft::run_retrieve_test_3(&table);
+}
+
+TEST(ProbingHashTableTest, StaticLinearProbingRetrieveTest6) {
+  int table_size = 2000;
+  int num_trials = 100;
+  uint64_t seed = 302342321;
+  std::mt19937_64 gen(seed);
+  std::uniform_int_distribution<uint64_t> dis(0,
+      std::numeric_limits<uint64_t>::max());
+
+  for (int ii = 0; ii < num_trials; ++ii) {
+    StaticLinearProbingHashTable<uint32_t> table(table_size);
+    uint64_t cur_seed = dis(gen);
+    ft::run_retrieve_test_4(&table, cur_seed);
+  }
+}
+
 TEST(ProbingHashTableTest, DynamicLinearProbingRetrieveTest1) {
   DynamicLinearProbingHashTable<uint32_t> table(0.5, 0.25, 3.0, 1);
   ft::run_dynamic_retrieve_test_1(&table);

--- a/src/test/probing_hash_table_test.cc
+++ b/src/test/probing_hash_table_test.cc
@@ -62,6 +62,12 @@ TEST(ProbingHashTableTest, StaticLinearProbingRetrieveTest6) {
   }
 }
 
+TEST(ProbingHashTableTest, StaticLinearProbingRetrieveTest7) {
+  int table_size = 4;
+  StaticLinearProbingHashTable<uint32_t> table(table_size);
+  ft::run_retrieve_test_5(&table);
+}
+
 TEST(ProbingHashTableTest, DynamicLinearProbingRetrieveTest1) {
   DynamicLinearProbingHashTable<uint32_t> table(0.5, 0.25, 3.0, 1);
   ft::run_dynamic_retrieve_test_1(&table);

--- a/src/test/stl_hash_table_test.cc
+++ b/src/test/stl_hash_table_test.cc
@@ -42,3 +42,8 @@ TEST(STLHashTableTest, RetrieveTest4) {
     ft::run_retrieve_test_4(&table, cur_seed);
   }
 }
+
+TEST(STLHashTableTest, RetrieveTest5) {
+  STLHashTable<uint32_t> table;
+  ft::run_retrieve_test_5(&table);
+}

--- a/src/test/stl_hash_table_test.cc
+++ b/src/test/stl_hash_table_test.cc
@@ -23,3 +23,22 @@ TEST(STLHashTableTest, RetrieveTest2) {
   STLHashTable<uint64_t> table;
   ft::run_retrieve_test_2(&table);
 }
+
+TEST(STLHashTableTest, RetrieveTest3) {
+  STLHashTable<uint32_t> table;
+  ft::run_retrieve_test_3(&table);
+}
+
+TEST(STLHashTableTest, RetrieveTest4) {
+  int num_trials = 100;
+  uint64_t seed = 302342321;
+  std::mt19937_64 gen(seed);
+  std::uniform_int_distribution<uint64_t> dis(0,
+      std::numeric_limits<uint64_t>::max());
+
+  for (int ii = 0; ii < num_trials; ++ii) {
+    STLHashTable<uint32_t> table;
+    uint64_t cur_seed = dis(gen);
+    ft::run_retrieve_test_4(&table, cur_seed);
+  }
+}

--- a/src/test/test_utils.h
+++ b/src/test/test_utils.h
@@ -170,6 +170,57 @@ void run_retrieve_test_4(HashTable* table, uint64_t seed) {
   }
 }
 
+// Written to catch an earlier bug in the bit-packed flat hash table
+// num_buckets = 10
+// num_items = 3
+template<typename HashTable>
+void run_retrieve_test_5(HashTable* table) {
+  typedef std::pair<typename HashTable::Iterator, typename HashTable::Iterator>
+      IteratorPair;
+  std::vector<uint32_t> entries = {7, 5, 7};
+  table->add_entries(entries);
+  
+  std::vector<int32_t> expected_result1 = {};
+  IteratorPair result1 = table->retrieve(0);
+  check_result(result1, expected_result1);
+
+  std::vector<int32_t> expected_result2 = {};
+  IteratorPair result2 = table->retrieve(1);
+  check_result(result2, expected_result2);
+
+  std::vector<int32_t> expected_result3 = {};
+  IteratorPair result3 = table->retrieve(2);
+  check_result(result3, expected_result3);
+
+  std::vector<int32_t> expected_result4 = {};
+  IteratorPair result4 = table->retrieve(3);
+  check_result(result4, expected_result4);
+
+  std::vector<int32_t> expected_result5 = {};
+  IteratorPair result5 = table->retrieve(4);
+  check_result(result5, expected_result5);
+  
+  std::vector<int32_t> expected_result6 = {1};
+  IteratorPair result6 = table->retrieve(5);
+  check_result(result6, expected_result6);
+  
+  std::vector<int32_t> expected_result7 = {};
+  IteratorPair result7 = table->retrieve(6);
+  check_result(result7, expected_result7);
+  
+  std::vector<int32_t> expected_result8 = {0, 2};
+  IteratorPair result8 = table->retrieve(7);
+  check_result(result8, expected_result8);
+  
+  std::vector<int32_t> expected_result9 = {};
+  IteratorPair result9 = table->retrieve(8);
+  check_result(result9, expected_result9);
+  
+  std::vector<int32_t> expected_result10 = {};
+  IteratorPair result10 = table->retrieve(9);
+  check_result(result10, expected_result10);
+}
+
 
 
 template<typename HashTable>

--- a/src/test/test_utils.h
+++ b/src/test/test_utils.h
@@ -103,6 +103,75 @@ void run_retrieve_test_2(HashTable* table) {
   check_result(result5, expected_result5);
 }
 
+// num_buckets = 8
+// num_items = 9
+template<typename HashTable>
+void run_retrieve_test_3(HashTable* table) {
+  typedef std::pair<typename HashTable::Iterator, typename HashTable::Iterator>
+      IteratorPair;
+  std::vector<uint32_t> entries = {3, 7, 1, 3, 2, 0, 5, 7, 6};
+  table->add_entries(entries);
+  
+  std::vector<int32_t> expected_result1 = {0, 3};
+  IteratorPair result1 = table->retrieve(3);
+  check_result(result1, expected_result1);
+
+  std::vector<int32_t> expected_result2 = {1, 7};
+  IteratorPair result2 = table->retrieve(7);
+  check_result(result2, expected_result2);
+
+  std::vector<int32_t> expected_result3 = {2};
+  IteratorPair result3 = table->retrieve(1);
+  check_result(result3, expected_result3);
+
+  std::vector<int32_t> expected_result4 = {6};
+  IteratorPair result4 = table->retrieve(5);
+  check_result(result4, expected_result4);
+
+  std::vector<int32_t> expected_result5 = {5};
+  IteratorPair result5 = table->retrieve(0);
+  check_result(result5, expected_result5);
+  
+  std::vector<int32_t> expected_result6 = {4};
+  IteratorPair result6 = table->retrieve(2);
+  check_result(result6, expected_result6);
+  
+  std::vector<int32_t> expected_result7 = {};
+  IteratorPair result7 = table->retrieve(4);
+  check_result(result7, expected_result7);
+}
+
+
+// num_buckets = 64
+// num_items = 1000
+template<typename HashTable>
+void run_retrieve_test_4(HashTable* table, uint64_t seed) {
+  typedef std::pair<typename HashTable::Iterator, typename HashTable::Iterator>
+      IteratorPair;
+  int_fast64_t num_buckets = 64;
+  int_fast64_t num_items = 1000;
+
+  std::mt19937_64 gen(seed);
+  std::uniform_int_distribution<> dis(0, num_buckets - 1);
+
+  std::vector<uint32_t> entries;
+  std::vector<std::vector<int_fast64_t>> expected_results(num_buckets);
+  for (int_fast64_t ii = 0; ii < num_items; ++ii) {
+    uint32_t key = dis(gen);
+    entries.push_back(key);
+    expected_results[key].push_back(ii);
+  }
+
+  table->add_entries(entries);
+
+  for (uint32_t ii = 0; ii < static_cast<uint32_t>(num_buckets); ++ii) {
+    IteratorPair result = table->retrieve(ii);
+    check_result(result, expected_results[ii]);
+  }
+}
+
+
+
 template<typename HashTable>
 void run_dynamic_retrieve_test_1(HashTable* table) {
   typedef std::pair<typename HashTable::Iterator, typename HashTable::Iterator>


### PR DESCRIPTION
- Added BitPackedFlatHashTable.
- Refactored the wrapper so that the storage hash table can now be chosen via a parameter.
- Removed the sorted candidate query methods.
- Added multi-threaded table setup.
- Updated the Python wrapper to reflect the changes above.
