### PR TITLE
Small fixes for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(IN
 
 CXX=g++
 CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -march=native -O3 -I external/eigen -I src/include
-SWIG=swig3.0
-NUMPY_INCLUDE_DIR=/usr/local/lib/python2.7/site-packages/numpy/core/include
+SWIG=swig
+NUMPY_INCLUDE_DIR= $(shell python -c "import numpy; print(numpy.get_include())")
 
 clean:
 	rm -rf obj

--- a/src/python/package/setup.py
+++ b/src/python/package/setup.py
@@ -2,7 +2,7 @@ import sys
 
 try:
     import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
+    long_description = pypandoc.convert('README.md', 'rst', format='md')
 except(IOError, ImportError):
     long_description = open('README.md').read()
 


### PR DESCRIPTION
I added some small fixes to the Makefile so that installing the Python package works for Python 3 (by doing `make python_package` followed by `pip install [path-to-falconn/python_pkg`).

See #14 and uses `swig` instead of `swig3.0` as suggested in #48.
