### PR TITLE
adds the possibility to create separatly Query object to use it in parallel in different threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,4 @@ matrix:
     - language: generic
       python: "OS X Python"
       os: osx
+      osx_image: xcode9

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ before_install:
     fi
 
 install:
-  - make python_package
-  - cd python_pkg/dist/FALCONN-* && pip install . && cd ../../..
+  - make python_package_install
 
 script:
   - make run_all_cpp_tests

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ DOC_DIR=doc
 
 ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(INC_DIR)/core/euclidean_distance.h $(INC_DIR)/core/composite_hash_table.h $(INC_DIR)/core/stl_hash_table.h $(INC_DIR)/core/polytope_hash.h $(INC_DIR)/core/flat_hash_table.h $(INC_DIR)/core/probing_hash_table.h $(INC_DIR)/core/hyperplane_hash.h $(INC_DIR)/core/heap.h $(INC_DIR)/core/prefetchers.h $(INC_DIR)/core/incremental_sorter.h $(INC_DIR)/core/lsh_function_helpers.h $(INC_DIR)/core/hash_table_helpers.h $(INC_DIR)/core/data_storage.h $(INC_DIR)/core/nn_query.h $(INC_DIR)/lsh_nn_table.h $(INC_DIR)/wrapper/cpp_wrapper_impl.h $(INC_DIR)/falconn_global.h $(TEST_DIR)/test_utils.h  $(INC_DIR)/core/data_transformation.h $(PYTHON_DIR)/wrapper/python_wrapper.h $(INC_DIR)/core/bit_packed_vector.h $(INC_DIR)/core/bit_packed_flat_hash_table.h
 
-CXX=g++-6
-CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -Wno-missing-braces -march=native -O3 -I external/eigen -I src/include
+CXX=g++
+CXXFLAGS=-std=c++11 -DNDEBUG -Wall -Wextra -Wno-missing-braces -march=native -O3 -I external/eigen -I src/include
 SWIG=swig
 NUMPY_INCLUDE_DIR= $(shell python -c "import numpy; print(numpy.get_include())")
 
@@ -159,24 +159,25 @@ $(TEST_BIN_DIR)/bit_packed_flat_hash_table_test: $(TEST_DIR)/bit_packed_flat_has
 	$(CXX) $(CXXFLAGS) -I $(GTEST_DIR)/include -c -o obj/bit_packed_flat_hash_table_test.o $(TEST_DIR)/bit_packed_flat_hash_table_test.cc
 	$(CXX) $(CXXFLAGS) -o $(TEST_BIN_DIR)/bit_packed_flat_hash_table_test obj/gtest_main.o obj/gtest-all.o obj/bit_packed_flat_hash_table_test.o -pthread
 
-run_all_cpp_tests: $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/euclidean_distance_test $(TEST_BIN_DIR)/flat_hash_table_test $(TEST_BIN_DIR)/probing_hash_table_test $(TEST_BIN_DIR)/stl_hash_table_test $(TEST_BIN_DIR)/composite_hash_table_test $(TEST_BIN_DIR)/polytope_hash_test $(TEST_BIN_DIR)/hyperplane_hash_test $(TEST_BIN_DIR)/lsh_table_test $(TEST_BIN_DIR)/heap_test $(TEST_BIN_DIR)/incremental_sorter_test $(TEST_BIN_DIR)/nn_query_test $(TEST_BIN_DIR)/cpp_wrapper_test $(TEST_BIN_DIR)/data_transformation_test $(TEST_BIN_DIR)/data_storage_test $(TEST_BIN_DIR)/bit_packed_vector_test $(TEST_BIN_DIR)/bit_packed_flat_hash_table_test
+run_all_cpp_tests: $(TEST_BIN_DIR)/bit_packed_flat_hash_table_test $(TEST_BIN_DIR)/bit_packed_vector_test $(TEST_BIN_DIR)/composite_hash_table_test $(TEST_BIN_DIR)/cosine_distance_test $(TEST_BIN_DIR)/cpp_wrapper_test $(TEST_BIN_DIR)/data_storage_test $(TEST_BIN_DIR)/data_transformation_test $(TEST_BIN_DIR)/euclidean_distance_test $(TEST_BIN_DIR)/flat_hash_table_test $(TEST_BIN_DIR)/heap_test $(TEST_BIN_DIR)/hyperplane_hash_test $(TEST_BIN_DIR)/incremental_sorter_test $(TEST_BIN_DIR)/lsh_table_test $(TEST_BIN_DIR)/nn_query_test $(TEST_BIN_DIR)/polytope_hash_test $(TEST_BIN_DIR)/probing_hash_table_test $(TEST_BIN_DIR)/stl_hash_table_test
+	./$(TEST_BIN_DIR)/bit_packed_flat_hash_table_test
+	./$(TEST_BIN_DIR)/bit_packed_vector_test
+	./$(TEST_BIN_DIR)/composite_hash_table_test
 	./$(TEST_BIN_DIR)/cosine_distance_test
+	./$(TEST_BIN_DIR)/cpp_wrapper_test
+	./$(TEST_BIN_DIR)/data_storage_test
+	./$(TEST_BIN_DIR)/data_transformation_test
 	./$(TEST_BIN_DIR)/euclidean_distance_test
 	./$(TEST_BIN_DIR)/flat_hash_table_test
+	./$(TEST_BIN_DIR)/heap_test
+	./$(TEST_BIN_DIR)/hyperplane_hash_test
+	./$(TEST_BIN_DIR)/incremental_sorter_test
+	./$(TEST_BIN_DIR)/lsh_table_test
+	./$(TEST_BIN_DIR)/nn_query_test
+	./$(TEST_BIN_DIR)/polytope_hash_test
 	./$(TEST_BIN_DIR)/probing_hash_table_test
 	./$(TEST_BIN_DIR)/stl_hash_table_test
-	./$(TEST_BIN_DIR)/composite_hash_table_test
-	./$(TEST_BIN_DIR)/polytope_hash_test
-	./$(TEST_BIN_DIR)/hyperplane_hash_test
-	./$(TEST_BIN_DIR)/lsh_table_test
-	./$(TEST_BIN_DIR)/heap_test
-	./$(TEST_BIN_DIR)/incremental_sorter_test
-	./$(TEST_BIN_DIR)/nn_query_test
-	./$(TEST_BIN_DIR)/cpp_wrapper_test
-	./$(TEST_BIN_DIR)/data_transformation_test
-	./$(TEST_BIN_DIR)/data_storage_test
-	./$(TEST_BIN_DIR)/bit_packed_vector_test
-	./$(TEST_BIN_DIR)/bit_packed_flat_hash_table_test
 
 run_all_python_tests: $(PYTHON_DIR)/test/wrapper_test.py
 	py.test src/python/test/wrapper_test.py
+	py.test src/python/test/module_test.py

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,15 @@ clean:
 docs: $(ALL_HEADERS) $(DOC_DIR)/Doxyfile
 	doxygen $(DOC_DIR)/Doxyfile
 
+python_swig_only:
+	rm -rf $(PYTHON_SWIG_DIR)
+	mkdir -p $(PYTHON_SWIG_DIR)
+	$(SWIG) -c++ -python -builtin -outdir $(PYTHON_SWIG_DIR) -o $(PYTHON_SWIG_DIR)/falconn_wrap.cc -Iexternal -Isrc/include $(PYTHON_DIR)/wrapper/falconn.i
+	mkdir -p obj
+	$(CXX) $(CXXFLAGS) -fPIC `python-config --includes` -I $(NUMPY_INCLUDE_DIR) -I $(INC_DIR) -I $(PYTHON_DIR)/wrapper -c $(PYTHON_SWIG_DIR)/falconn_wrap.cc -o obj/falconn_wrap.o
+	$(CXX) -shared obj/falconn_wrap.o -o $(PYTHON_SWIG_DIR)/_falconn.so `python-config --ldflags` -lc++
+	rm -f $(PYTHON_SWIG_DIR)/falconn_wrap.cxx
+
 python_package:
 	rm -rf $(PYTHON_PKG_DIR)
 	mkdir -p $(PYTHON_PKG_DIR)

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ DOC_DIR=doc
 
 ALL_HEADERS = $(INC_DIR)/core/lsh_table.h $(INC_DIR)/core/cosine_distance.h $(INC_DIR)/core/euclidean_distance.h $(INC_DIR)/core/composite_hash_table.h $(INC_DIR)/core/stl_hash_table.h $(INC_DIR)/core/polytope_hash.h $(INC_DIR)/core/flat_hash_table.h $(INC_DIR)/core/probing_hash_table.h $(INC_DIR)/core/hyperplane_hash.h $(INC_DIR)/core/heap.h $(INC_DIR)/core/prefetchers.h $(INC_DIR)/core/incremental_sorter.h $(INC_DIR)/core/lsh_function_helpers.h $(INC_DIR)/core/hash_table_helpers.h $(INC_DIR)/core/data_storage.h $(INC_DIR)/core/nn_query.h $(INC_DIR)/lsh_nn_table.h $(INC_DIR)/wrapper/cpp_wrapper_impl.h $(INC_DIR)/falconn_global.h $(TEST_DIR)/test_utils.h  $(INC_DIR)/core/data_transformation.h $(PYTHON_DIR)/wrapper/python_wrapper.h $(INC_DIR)/core/bit_packed_vector.h $(INC_DIR)/core/bit_packed_flat_hash_table.h
 
-CXX=g++
-CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -march=native -O3 -I external/eigen -I src/include
+CXX=g++-6
+CXXFLAGS=-std=gnu++11 -DNDEBUG -Wall -Wextra -Wno-missing-braces -march=native -O3 -I external/eigen -I src/include
 SWIG=swig
 NUMPY_INCLUDE_DIR= $(shell python -c "import numpy; print(numpy.get_include())")
 
@@ -30,7 +30,7 @@ docs: $(ALL_HEADERS) $(DOC_DIR)/Doxyfile
 python_swig_only:
 	rm -rf $(PYTHON_SWIG_DIR)
 	mkdir -p $(PYTHON_SWIG_DIR)
-	$(SWIG) -c++ -python -builtin -outdir $(PYTHON_SWIG_DIR) -o $(PYTHON_SWIG_DIR)/falconn_wrap.cc -Iexternal -Isrc/include $(PYTHON_DIR)/wrapper/falconn.i
+	$(SWIG) -c++ -python -threads -builtin -outdir $(PYTHON_SWIG_DIR) -o $(PYTHON_SWIG_DIR)/falconn_wrap.cc -Iexternal -Isrc/include $(PYTHON_DIR)/wrapper/falconn.i
 	mkdir -p obj
 	$(CXX) $(CXXFLAGS) -fPIC `python-config --includes` -I $(NUMPY_INCLUDE_DIR) -I $(INC_DIR) -I $(PYTHON_DIR)/wrapper -c $(PYTHON_SWIG_DIR)/falconn_wrap.cc -o obj/falconn_wrap.o
 	$(CXX) -shared obj/falconn_wrap.o -o $(PYTHON_SWIG_DIR)/_falconn.so `python-config --ldflags` -lc++

--- a/src/benchmark/random_benchmark.cc
+++ b/src/benchmark/random_benchmark.cc
@@ -40,7 +40,7 @@ using falconn::StorageHashTable;
 typedef falconn::DenseVector<float> Vec;
 
 class Timer {
-public:
+ public:
   Timer() { start_time = high_resolution_clock::now(); }
 
   double elapsed_seconds() {
@@ -49,17 +49,15 @@ public:
     return elapsed.count();
   }
 
-private:
+ private:
   high_resolution_clock::time_point start_time;
 };
 
 template <typename PointType>
 void thread_function(LSHNearestNeighborQueryPool<PointType>* query_pool,
                      const vector<PointType>& queries,
-                     const vector<int>& true_nns,
-                     int query_index_start,
-                     int query_index_end,
-                     int* num_correct_in_thread,
+                     const vector<int>& true_nns, int query_index_start,
+                     int query_index_end, int* num_correct_in_thread,
                      double* total_query_time_outside_in_thread) {
   for (int ii = query_index_start; ii < query_index_end; ++ii) {
     Timer query_time;
@@ -76,10 +74,8 @@ void thread_function(LSHNearestNeighborQueryPool<PointType>* query_pool,
 template <typename PointType>
 void run_experiment(LSHNearestNeighborTable<PointType>* table,
                     const vector<PointType>& queries,
-                    const vector<int>& true_nns,
-                    int num_probes,
-                    int num_threads,
-                    double* avg_query_time,
+                    const vector<int>& true_nns, int num_probes,
+                    int num_threads, double* avg_query_time,
                     double* success_probability) {
   unique_ptr<LSHNearestNeighborQueryPool<PointType>> query_pool(
       table->construct_query_pool(num_probes));
@@ -104,13 +100,9 @@ void run_experiment(LSHNearestNeighborTable<PointType>* table,
   Timer total_time;
 
   for (int ii = 0; ii < num_threads; ++ii) {
-    threads.push_back(thread(thread_function<PointType>,
-                             query_pool.get(),
-                             cref(queries),
-                             cref(true_nns),
-                             index_start[ii],
-                             index_end[ii],
-                             &(num_correct_per_thread[ii]),
+    threads.push_back(thread(thread_function<PointType>, query_pool.get(),
+                             cref(queries), cref(true_nns), index_start[ii],
+                             index_end[ii], &(num_correct_per_thread[ii]),
                              &(total_query_time_outside_per_thread[ii])));
   }
   for (int ii = 0; ii < num_threads; ++ii) {
@@ -152,9 +144,9 @@ void run_experiment(LSHNearestNeighborTable<PointType>* table,
        << stats.average_num_unique_candidates << endl
        << endl;
   cout << "Diagnostics:" << endl;
-  double threading_imbalance = total_computation_time
-                                  - average_query_time_outside * queries.size()
-                                      / num_threads;
+  double threading_imbalance =
+      total_computation_time -
+      average_query_time_outside * queries.size() / num_threads;
   cout << "Threading imbalance (total_wall_clock_time - sum of query times "
        << "outside / num_threads): " << threading_imbalance << " seconds ("
        << 100.0 * threading_imbalance / total_computation_time
@@ -178,9 +170,9 @@ int main() {
         "-";
 
     // Data set parameters
-    int n = 1000000;                  // number of data points
-    int d = 128;                      // dimension
-    int num_queries = 1000;           // number of query points
+    int n = 1000000;             // number of data points
+    int d = 128;                 // dimension
+    int num_queries = 1000;      // number of query points
     double r = sqrt(2.0) / 2.0;  // distance to planted query
     uint64_t seed = 119417657;
 

--- a/src/benchmark/random_benchmark.cc
+++ b/src/benchmark/random_benchmark.cc
@@ -24,6 +24,7 @@ using falconn::DenseVector;
 using falconn::DistanceFunction;
 using falconn::LSHConstructionParameters;
 using falconn::LSHFamily;
+using falconn::LSHNearestNeighborQueryPool;
 using falconn::LSHNearestNeighborTable;
 using falconn::QueryStatistics;
 using falconn::StorageHashTable;
@@ -45,34 +46,90 @@ class Timer {
 };
 
 template <typename PointType>
-void run_experiment(LSHNearestNeighborTable<PointType>* table,
-                    const std::vector<PointType> queries,
-                    const std::vector<int> true_nns, double* avg_query_time,
-                    double* success_probability) {
-  double average_query_time_outside = 0.0;
-  int num_correct = 0;
-
-  for (int ii = 0; ii < static_cast<int>(queries.size()); ++ii) {
+void thread_function(LSHNearestNeighborQueryPool<PointType>* query_pool,
+                     const std::vector<PointType>& queries,
+                     const std::vector<int>& true_nns,
+                     int query_index_start,
+                     int query_index_end,
+                     int* num_correct_in_thread,
+                     double* total_query_time_outside_in_thread) {
+  for (int ii = query_index_start; ii < query_index_end; ++ii) {
     Timer query_time;
 
-    int32_t res = table->find_nearest_neighbor(queries[ii]);
+    int32_t res = query_pool->find_nearest_neighbor(queries[ii]);
 
-    average_query_time_outside += query_time.elapsed_seconds();
+    *total_query_time_outside_in_thread += query_time.elapsed_seconds();
     if (res == true_nns[ii]) {
-      num_correct += 1;
+      *num_correct_in_thread += 1;
     }
   }
+}
 
+template <typename PointType>
+void run_experiment(LSHNearestNeighborTable<PointType>* table,
+                    const std::vector<PointType>& queries,
+                    const std::vector<int>& true_nns,
+                    int num_probes,
+                    int num_threads,
+                    double* avg_query_time,
+                    double* success_probability) {
+  std::unique_ptr<LSHNearestNeighborQueryPool<PointType>> query_pool(
+      table->construct_query_pool(num_probes));
+  std::vector<int> num_correct_per_thread(num_threads, 0);
+  std::vector<double> total_query_time_outside_per_thread(num_threads, 0.0);
+  std::vector<int> index_start(num_threads, 0);
+  std::vector<int> index_end(num_threads, 0);
+
+  int queries_per_thread = queries.size() / num_threads;
+  int remainder = queries.size() % num_threads;
+  int last_end = 0;
+  for (int ii = 0; ii < num_threads; ++ii) {
+    index_start[ii] = last_end;
+    index_end[ii] = last_end + queries_per_thread;
+    if (ii < remainder) {
+      index_end[ii] += 1;
+    }
+    last_end = index_end[ii];
+  }
+
+  std::vector<std::thread> threads;
+  Timer total_time;
+
+  for (int ii = 0; ii < num_threads; ++ii) {
+    threads.push_back(std::thread(thread_function<PointType>,
+                                  query_pool.get(),
+                                  std::cref(queries),
+                                  std::cref(true_nns),
+                                  index_start[ii],
+                                  index_end[ii],
+                                  &(num_correct_per_thread[ii]),
+                                  &(total_query_time_outside_per_thread[ii])));
+  }
+  for (int ii = 0; ii < num_threads; ++ii) {
+    threads[ii].join();
+  }
+
+  double total_computation_time = total_time.elapsed_seconds();
+  
+  double average_query_time_outside = 0.0;
+  *success_probability = 0.0;
+  for (int ii = 0; ii < num_threads; ++ii) {
+    *success_probability += num_correct_per_thread[ii];
+    average_query_time_outside += total_query_time_outside_per_thread[ii];
+  }
+  *success_probability /= queries.size();
   average_query_time_outside /= queries.size();
   *avg_query_time = average_query_time_outside;
-  *success_probability = static_cast<double>(num_correct) / queries.size();
+ 
+  cout << "Total experiment wall clock time: " << scientific
+       << total_computation_time << " seconds" << endl;
   cout << "Average query time (measured outside): " << scientific
        << average_query_time_outside << " seconds" << endl;
   cout << "Empirical success probability: " << fixed << *success_probability
        << endl
        << endl;
   cout << "Query statistics:" << endl;
-  QueryStatistics stats = table->get_query_statistics();
+  QueryStatistics stats = query_pool->get_query_statistics();
   cout << "Average total query time: " << scientific
        << stats.average_total_query_time << " seconds" << endl;
   cout << "Average LSH time:         " << stats.average_lsh_time << " seconds"
@@ -87,6 +144,13 @@ void run_experiment(LSHNearestNeighborTable<PointType>* table,
        << stats.average_num_unique_candidates << endl
        << endl;
   cout << "Diagnostics:" << endl;
+  double threading_imbalance = total_computation_time
+                                  - average_query_time_outside * queries.size()
+                                      / num_threads;
+  cout << "Threading imbalance (total_wall_clock_time - sum of query times "
+       << "outside / num_threads): " << threading_imbalance << " seconds ("
+       << 100.0 * threading_imbalance / total_computation_time
+       << " % of the total wall clock time)" << endl;
   double mismatch = average_query_time_outside - stats.average_total_query_time;
   cout << "Outside - inside average total query time: " << scientific
        << mismatch << " seconds (" << fixed
@@ -115,11 +179,16 @@ int main() {
     // Common LSH parameters
     int num_tables = 10;
     int num_setup_threads = 0;
+    // TODO: make this a program argument (should we use a parsing library?)
+    int num_query_threads = 1;
     StorageHashTable storage_hash_table = StorageHashTable::FlatHashTable;
     DistanceFunction distance_function = DistanceFunction::NegativeInnerProduct;
 
     cout << sepline << endl;
-    cout << "FALCONN C++ random data benchmark" << endl;
+    cout << "FALCONN C++ random data benchmark" << endl << endl;
+    cout << "std::thread::hardware_concurrency(): "
+         << std::thread::hardware_concurrency() << endl;
+    cout << "num_query_threads = " << num_query_threads << endl << endl;
     cout << "Data set parameters: " << endl;
     cout << "n = " << n << endl;
     cout << "d = " << d << endl;
@@ -200,6 +269,7 @@ int main() {
     params_hp.l = num_tables;
     params_hp.num_setup_threads = num_setup_threads;
     params_hp.seed = seed ^ 833840234;
+    int num_probes_hp = 2464;
 
     cout << "Hyperplane hash" << endl << endl;
 
@@ -207,20 +277,19 @@ int main() {
 
     unique_ptr<LSHNearestNeighborTable<Vec>> hptable(
         std::move(construct_table<Vec>(data, params_hp)));
-    hptable->set_num_probes(2464);
 
     double hp_construction_time = hp_construction.elapsed_seconds();
 
     cout << "k = " << params_hp.k << endl;
     cout << "l = " << params_hp.l << endl;
-    cout << "Number of probes = " << hptable->get_num_probes() << endl;
+    cout << "Number of probes = " << num_probes_hp << endl;
     cout << "Construction time: " << hp_construction_time << " seconds" << endl
          << endl;
 
     double hp_avg_time;
     double hp_success_prob;
-    run_experiment(hptable.get(), queries, true_nn, &hp_avg_time,
-                   &hp_success_prob);
+    run_experiment(hptable.get(), queries, true_nn, num_probes_hp,
+                   num_query_threads, &hp_avg_time, &hp_success_prob);
     cout << sepline << endl;
     hptable.reset(nullptr);
 
@@ -236,6 +305,7 @@ int main() {
     params_cp.num_rotations = 3;
     params_cp.num_setup_threads = num_setup_threads;
     params_cp.seed = seed ^ 833840234;
+    int num_probes_cp = 896;
 
     cout << "Cross polytope hash" << endl << endl;
 
@@ -243,7 +313,6 @@ int main() {
 
     unique_ptr<LSHNearestNeighborTable<Vec>> cptable(
         std::move(construct_table<Vec>(data, params_cp)));
-    cptable->set_num_probes(896);
 
     double cp_construction_time = cp_construction.elapsed_seconds();
 
@@ -251,14 +320,14 @@ int main() {
     cout << "last_cp_dim = " << params_cp.last_cp_dimension << endl;
     cout << "num_rotations = " << params_cp.num_rotations << endl;
     cout << "l = " << params_cp.l << endl;
-    cout << "Number of probes = " << cptable->get_num_probes() << endl;
+    cout << "Number of probes = " << num_probes_cp << endl;
     cout << "Construction time: " << cp_construction_time << " seconds" << endl
          << endl;
 
     double cp_avg_time;
     double cp_success_prob;
-    run_experiment(cptable.get(), queries, true_nn, &cp_avg_time,
-                   &cp_success_prob);
+    run_experiment(cptable.get(), queries, true_nn, num_probes_cp,
+                   num_query_threads, &cp_avg_time, &cp_success_prob);
 
     cout << sepline << endl << "Summary:" << endl;
     cout << "Success probabilities:" << endl;

--- a/src/examples/glove/glove.cc
+++ b/src/examples/glove/glove.cc
@@ -31,9 +31,11 @@
 #include <algorithm>
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <random>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <cstdio>
@@ -42,11 +44,14 @@ using std::cerr;
 using std::cout;
 using std::endl;
 using std::exception;
+using std::make_pair;
 using std::max;
 using std::mt19937_64;
+using std::pair;
 using std::runtime_error;
 using std::string;
 using std::uniform_int_distribution;
+using std::unique_ptr;
 using std::vector;
 
 using std::chrono::duration;
@@ -60,6 +65,8 @@ using falconn::DistanceFunction;
 using falconn::LSHConstructionParameters;
 using falconn::LSHFamily;
 using falconn::LSHNearestNeighborTable;
+using falconn::LSHNearestNeighborQuery;
+using falconn::QueryStatistics;
 using falconn::StorageHashTable;
 using falconn::get_default_parameters;
 
@@ -165,12 +172,12 @@ void gen_answers(const vector<Point> &dataset, const vector<Point> &queries,
 double evaluate_num_probes(LSHNearestNeighborTable<Point> *table,
                            const vector<Point> &queries,
                            const vector<int> &answers, int num_probes) {
-  table->set_num_probes(num_probes);
+  unique_ptr<LSHNearestNeighborQuery<Point>> query_object = table->construct_query_object(num_probes);
   int outer_counter = 0;
   int num_matches = 0;
   vector<int32_t> candidates;
   for (const auto &query : queries) {
-    table->get_candidates_with_duplicates(query, &candidates);
+    query_object->get_candidates_with_duplicates(query, &candidates);
     for (auto x : candidates) {
       if (x == answers[outer_counter]) {
         ++num_matches;
@@ -187,19 +194,20 @@ double evaluate_num_probes(LSHNearestNeighborTable<Point> *table,
  * It is much slower than 'evaluate_num_probes' and should be used to
  * measure the time.
  */
-double evaluate_query_time(LSHNearestNeighborTable<Point> *table,
+pair<double, QueryStatistics> evaluate_query_time(LSHNearestNeighborTable<Point> *table,
                            const vector<Point> &queries,
                            const vector<int> &answers, int num_probes) {
-  table->set_num_probes(num_probes);
+  unique_ptr<LSHNearestNeighborQuery<Point>> query_object = table->construct_query_object(num_probes);
+  query_object->reset_query_statistics();
   int outer_counter = 0;
   int num_matches = 0;
   for (const auto &query : queries) {
-    if (table->find_nearest_neighbor(query) == answers[outer_counter]) {
+    if (query_object->find_nearest_neighbor(query) == answers[outer_counter]) {
       ++num_matches;
     }
     ++outer_counter;
   }
-  return (num_matches + 0.0) / (queries.size() + 0.0);
+  return make_pair((num_matches + 0.0) / (queries.size() + 0.0), query_object->get_query_statistics());
 }
 
 /*
@@ -318,9 +326,9 @@ int main() {
 
     // executing the queries using the found number of probes to gather
     // statistics
-    table->reset_query_statistics();
-    double score = evaluate_query_time(&*table, queries, answers, num_probes);
-    auto statistics = table->get_query_statistics();
+    auto tmp = evaluate_query_time(&*table, queries, answers, num_probes);
+    auto score = tmp.first;
+    auto statistics = tmp.second;
     cout << "average total query time: " << statistics.average_total_query_time
          << endl;
     cout << "average lsh time: " << statistics.average_lsh_time << endl;

--- a/src/examples/glove/glove.cc
+++ b/src/examples/glove/glove.cc
@@ -172,7 +172,8 @@ void gen_answers(const vector<Point> &dataset, const vector<Point> &queries,
 double evaluate_num_probes(LSHNearestNeighborTable<Point> *table,
                            const vector<Point> &queries,
                            const vector<int> &answers, int num_probes) {
-  unique_ptr<LSHNearestNeighborQuery<Point>> query_object = table->construct_query_object(num_probes);
+  unique_ptr<LSHNearestNeighborQuery<Point>> query_object =
+      table->construct_query_object(num_probes);
   int outer_counter = 0;
   int num_matches = 0;
   vector<int32_t> candidates;
@@ -194,10 +195,11 @@ double evaluate_num_probes(LSHNearestNeighborTable<Point> *table,
  * It is much slower than 'evaluate_num_probes' and should be used to
  * measure the time.
  */
-pair<double, QueryStatistics> evaluate_query_time(LSHNearestNeighborTable<Point> *table,
-                           const vector<Point> &queries,
-                           const vector<int> &answers, int num_probes) {
-  unique_ptr<LSHNearestNeighborQuery<Point>> query_object = table->construct_query_object(num_probes);
+pair<double, QueryStatistics> evaluate_query_time(
+    LSHNearestNeighborTable<Point> *table, const vector<Point> &queries,
+    const vector<int> &answers, int num_probes) {
+  unique_ptr<LSHNearestNeighborQuery<Point>> query_object =
+      table->construct_query_object(num_probes);
   query_object->reset_query_statistics();
   int outer_counter = 0;
   int num_matches = 0;
@@ -207,7 +209,8 @@ pair<double, QueryStatistics> evaluate_query_time(LSHNearestNeighborTable<Point>
     }
     ++outer_counter;
   }
-  return make_pair((num_matches + 0.0) / (queries.size() + 0.0), query_object->get_query_statistics());
+  return make_pair((num_matches + 0.0) / (queries.size() + 0.0),
+                   query_object->get_query_statistics());
 }
 
 /*

--- a/src/examples/glove/glove.py
+++ b/src/examples/glove/glove.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     print('Reading the dataset')
     dataset = np.load(dataset_file)
     print('Done')
-    
+
     # It's important not to use doubles, unless they are strictly necessary.
     # If your dataset consists of doubles, convert it to floats using `astype`.
     assert dataset.dtype == np.float32
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     answers = []
     for query in queries:
         answers.append(np.dot(dataset, query).argmax())
-    t2 = timeit.default_timer()    
+    t2 = timeit.default_timer()
     print('Done')
     print('Linear scan time: {} per query'.format((t2 - t1) / float(len(queries))))
 

--- a/src/examples/glove/glove.py
+++ b/src/examples/glove/glove.py
@@ -41,7 +41,8 @@ if __name__ == '__main__':
         answers.append(np.dot(dataset, query).argmax())
     t2 = timeit.default_timer()
     print('Done')
-    print('Linear scan time: {} per query'.format((t2 - t1) / float(len(queries))))
+    print('Linear scan time: {} per query'.format((t2 - t1) / float(
+        len(queries))))
 
     # Center the dataset and the queries: this improves the performance of LSH quite a bit.
     print('Centering the dataset and queries')
@@ -79,6 +80,7 @@ if __name__ == '__main__':
     # using the binary search
     print('Choosing number of probes')
     number_of_probes = number_of_tables
+
     def evaluate_number_of_probes(number_of_probes):
         table.set_num_probes(number_of_probes)
         score = 0
@@ -86,6 +88,7 @@ if __name__ == '__main__':
             if answers[i] in table.get_candidates_with_duplicates(query):
                 score += 1
         return float(score) / len(queries)
+
     while True:
         accuracy = evaluate_number_of_probes(number_of_probes)
         print('{} -> {}'.format(number_of_probes, accuracy))

--- a/src/include/falconn/core/bit_packed_flat_hash_table.h
+++ b/src/include/falconn/core/bit_packed_flat_hash_table.h
@@ -99,7 +99,7 @@ class BitPackedFlatHashTable {
           "Incorrect number of items in add_entries.");
     }
 
-    std::vector<IndexType> bucket_counts(num_buckets_,  0);
+    std::vector<IndexType> bucket_counts(num_buckets_, 0);
     for (IndexType ii = 0; ii < static_cast<IndexType>(keys.size()); ++ii) {
       if (static_cast<IndexType>(keys[ii]) >= num_buckets_ || keys[ii] < 0) {
         throw BitPackedFlatHashTableError("Key value out of range.");
@@ -111,12 +111,11 @@ class BitPackedFlatHashTable {
     for (IndexType ii = 1; ii < num_buckets_; ++ii) {
       bucket_start_.set(ii, bucket_start_.get(ii - 1) + bucket_counts[ii - 1]);
     }
-    
+
     for (IndexType ii = static_cast<IndexType>(keys.size()) - 1; ii >= 0;
-        --ii) {
+         --ii) {
       KeyType cur_key = keys[ii];
-      indices_.set(bucket_start_.get(cur_key) + bucket_counts[cur_key] - 1,
-                   ii);
+      indices_.set(bucket_start_.get(cur_key) + bucket_counts[cur_key] - 1, ii);
       bucket_counts[cur_key] -= 1;
     }
   }

--- a/src/include/falconn/core/lsh_table.h
+++ b/src/include/falconn/core/lsh_table.h
@@ -117,8 +117,12 @@ class StaticLSHTable
                                         int_fast64_t num_probes,
                                         int_fast64_t max_num_candidates,
                                         std::vector<KeyType>* result) {
+      if (result == nullptr) {
+        throw LSHTableError("Results vector pointer is nullptr.");
+      }
+
       auto start_time = std::chrono::high_resolution_clock::now();
-      stats_num_queries_ += 1;
+      stats_.num_queries += 1;
 
       lsh_query_.get_probes_by_table(p, &tmp_probes_by_table_, num_probes);
 
@@ -161,8 +165,12 @@ class StaticLSHTable
     void get_unique_candidates(const PointType& p, int_fast64_t num_probes,
                                int_fast64_t max_num_candidates,
                                std::vector<KeyType>* result) {
+      if (result == nullptr) {
+        throw LSHTableError("Results vector pointer is nullptr.");
+      }
+
       auto start_time = std::chrono::high_resolution_clock::now();
-      stats_num_queries_ += 1;
+      stats_.num_queries += 1;
 
       get_unique_candidates_internal(p, num_probes, max_num_candidates, result);
 
@@ -173,42 +181,13 @@ class StaticLSHTable
       stats_.average_total_query_time += elapsed_total.count();
     }
 
-    /*void get_unique_sorted_candidates(const PointType& p,
-                                      int_fast64_t num_probes,
-                                      int_fast64_t max_num_candidates,
-                                      std::vector<KeyType>* result) {
-      auto start_time = std::chrono::high_resolution_clock::now();
-      stats_num_queries_ += 1;
-
-      get_unique_candidates_internal(p, num_probes, max_num_candidates, result);
-      std::sort(result->begin(), result->end());
-
-      auto end_time = std::chrono::high_resolution_clock::now();
-      auto elapsed_total = std::chrono::duration_cast<
-          std::chrono::duration<double>>(end_time - start_time);
-      stats_.average_total_query_time += elapsed_total.count();
-    }*/
-
     void reset_query_statistics() {
-      stats_num_queries_ = 0;
-      stats_.average_total_query_time = 0.0;
-      stats_.average_lsh_time = 0.0;
-      stats_.average_hash_table_time = 0.0;
-      stats_.average_distance_time = 0.0;
-      stats_.average_num_candidates = 0.0;
-      stats_.average_num_unique_candidates = 0.0;
+      stats_.reset();
     }
 
     QueryStatistics get_query_statistics() {
       QueryStatistics res = stats_;
-      if (stats_num_queries_ > 0) {
-        res.average_total_query_time /= stats_num_queries_;
-        res.average_lsh_time /= stats_num_queries_;
-        res.average_hash_table_time /= stats_num_queries_;
-        res.average_distance_time /= stats_num_queries_;
-        res.average_num_candidates /= stats_num_queries_;
-        res.average_num_unique_candidates /= stats_num_queries_;
-      }
+      res.compute_averages();
       return res;
     }
 
@@ -225,7 +204,6 @@ class StaticLSHTable
         hash_table_iterators_;
 
     QueryStatistics stats_;
-    int_fast64_t stats_num_queries_ = 0;
 
     void get_unique_candidates_internal(const PointType& p,
                                         int_fast64_t num_probes,

--- a/src/include/falconn/core/lsh_table.h
+++ b/src/include/falconn/core/lsh_table.h
@@ -181,9 +181,7 @@ class StaticLSHTable
       stats_.average_total_query_time += elapsed_total.count();
     }
 
-    void reset_query_statistics() {
-      stats_.reset();
-    }
+    void reset_query_statistics() { stats_.reset(); }
 
     QueryStatistics get_query_statistics() {
       QueryStatistics res = stats_;

--- a/src/include/falconn/core/nn_query.h
+++ b/src/include/falconn/core/nn_query.h
@@ -187,26 +187,26 @@ class NearestNeighborQuery {
                                       int_fast64_t max_num_candidates,
                                       std::vector<LSHTableKeyType>* result) {
     auto start_time = std::chrono::high_resolution_clock::now();
-    
+
     table_query_->get_candidates_with_duplicates(q, num_probes,
                                                  max_num_candidates, result);
-    
+
     auto end_time = std::chrono::high_resolution_clock::now();
     auto elapsed_total =
         std::chrono::duration_cast<std::chrono::duration<double>>(end_time -
                                                                   start_time);
     stats_.average_total_query_time += elapsed_total.count();
   }
-  
+
   void get_unique_candidates(const LSHTablePointType& q,
                              int_fast64_t num_probes,
                              int_fast64_t max_num_candidates,
                              std::vector<LSHTableKeyType>* result) {
     auto start_time = std::chrono::high_resolution_clock::now();
-    
+
     table_query_->get_unique_candidates(q, num_probes, max_num_candidates,
                                         result);
-    
+
     auto end_time = std::chrono::high_resolution_clock::now();
     auto elapsed_total =
         std::chrono::duration_cast<std::chrono::duration<double>>(end_time -

--- a/src/include/falconn/core/nn_query.h
+++ b/src/include/falconn/core/nn_query.h
@@ -36,7 +36,6 @@ class NearestNeighborQuery {
                                         int_fast64_t num_probes,
                                         int_fast64_t max_num_candidates) {
     auto start_time = std::chrono::high_resolution_clock::now();
-    stats_num_queries_ += 1;
 
     table_query_->get_unique_candidates(q, num_probes, max_num_candidates,
                                         &candidates_);
@@ -90,7 +89,6 @@ class NearestNeighborQuery {
     }
 
     auto start_time = std::chrono::high_resolution_clock::now();
-    stats_num_queries_ += 1;
 
     std::vector<LSHTableKeyType>& res = *result;
     res.clear();
@@ -155,7 +153,6 @@ class NearestNeighborQuery {
     }
 
     auto start_time = std::chrono::high_resolution_clock::now();
-    stats_num_queries_ += 1;
 
     std::vector<LSHTableKeyType>& res = *result;
     res.clear();
@@ -185,15 +182,41 @@ class NearestNeighborQuery {
     stats_.average_total_query_time += elapsed_total.count();
   }
 
+  void get_candidates_with_duplicates(const LSHTablePointType& q,
+                                      int_fast64_t num_probes,
+                                      int_fast64_t max_num_candidates,
+                                      std::vector<LSHTableKeyType>* result) {
+    auto start_time = std::chrono::high_resolution_clock::now();
+    
+    table_query_->get_candidates_with_duplicates(q, num_probes,
+                                                 max_num_candidates, result);
+    
+    auto end_time = std::chrono::high_resolution_clock::now();
+    auto elapsed_total =
+        std::chrono::duration_cast<std::chrono::duration<double>>(end_time -
+                                                                  start_time);
+    stats_.average_total_query_time += elapsed_total.count();
+  }
+  
+  void get_unique_candidates(const LSHTablePointType& q,
+                             int_fast64_t num_probes,
+                             int_fast64_t max_num_candidates,
+                             std::vector<LSHTableKeyType>* result) {
+    auto start_time = std::chrono::high_resolution_clock::now();
+    
+    table_query_->get_unique_candidates(q, num_probes, max_num_candidates,
+                                        result);
+    
+    auto end_time = std::chrono::high_resolution_clock::now();
+    auto elapsed_total =
+        std::chrono::duration_cast<std::chrono::duration<double>>(end_time -
+                                                                  start_time);
+    stats_.average_total_query_time += elapsed_total.count();
+  }
+
   void reset_query_statistics() {
     table_query_->reset_query_statistics();
-    stats_num_queries_ = 0;
-    stats_.average_total_query_time = 0.0;
-    stats_.average_lsh_time = 0.0;
-    stats_.average_hash_table_time = 0.0;
-    stats_.average_distance_time = 0.0;
-    stats_.average_num_candidates = 0.0;
-    stats_.average_num_unique_candidates = 0.0;
+    stats_.reset();
   }
 
   QueryStatistics get_query_statistics() {
@@ -201,9 +224,9 @@ class NearestNeighborQuery {
     res.average_total_query_time = stats_.average_total_query_time;
     res.average_distance_time = stats_.average_distance_time;
 
-    if (stats_num_queries_ > 0) {
-      res.average_total_query_time /= stats_num_queries_;
-      res.average_distance_time /= stats_num_queries_;
+    if (res.num_queries > 0) {
+      res.average_total_query_time /= res.num_queries;
+      res.average_distance_time /= res.num_queries;
     }
     return res;
   }
@@ -216,7 +239,6 @@ class NearestNeighborQuery {
   SimpleHeap<DistanceType, LSHTableKeyType> heap_;
 
   QueryStatistics stats_;
-  int_fast64_t stats_num_queries_ = 0;
 };
 
 }  // namespace core

--- a/src/include/falconn/falconn_global.h
+++ b/src/include/falconn/falconn_global.h
@@ -100,6 +100,51 @@ struct QueryStatistics {
   /// Average number of *unique* candidates
   ///
   double average_num_unique_candidates = 0;
+  ///
+  /// Number of queries the statistics were computed over
+  ///
+  int_fast64_t num_queries = 0;
+
+  // TODO: move these to internal helper functions?
+  void convert_to_totals() {
+    average_total_query_time *= num_queries;
+    average_lsh_time *= num_queries;
+    average_hash_table_time *= num_queries;
+    average_distance_time *= num_queries;
+    average_num_candidates *= num_queries;
+    average_num_unique_candidates *= num_queries;
+  }
+
+  void compute_averages() {
+    if (num_queries > 0) {
+      average_total_query_time /= num_queries;
+      average_lsh_time /= num_queries;
+      average_hash_table_time /= num_queries;
+      average_distance_time /= num_queries;
+      average_num_candidates /= num_queries;
+      average_num_unique_candidates /= num_queries;
+    }
+  }
+
+  void add_totals(const QueryStatistics& other) {
+    average_total_query_time += other.average_total_query_time;
+    average_lsh_time += other.average_lsh_time;
+    average_hash_table_time += other.average_hash_table_time;
+    average_distance_time += other.average_distance_time;
+    average_num_candidates += other.average_num_candidates;
+    average_num_unique_candidates += other.average_num_unique_candidates;
+    num_queries += other.num_queries;
+  }
+
+  void reset() {
+    average_total_query_time = 0.0;
+    average_lsh_time = 0.0;
+    average_hash_table_time = 0.0;
+    average_distance_time = 0.0;
+    average_num_candidates = 0.0;
+    average_num_unique_candidates = 0.0;
+    num_queries = 0;
+  }
 };
 
 }  // namespace falconn

--- a/src/include/falconn/ffht/best_chunk.cpp
+++ b/src/include/falconn/ffht/best_chunk.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <chrono>
 #include <iostream>
-#include <stdexcept>
 #include <map>
+#include <stdexcept>
 
 #include <cstdlib>
 
@@ -16,40 +16,41 @@ double measureTime(int n, int times, int chunk, bool isDouble) {
     if (res) {
       throw std::runtime_error("error in posix_memalign");
     }
-    a = (double*)aux;
+    a = (double *)aux;
     for (int i = 0; i < n; ++i) {
       a[i] = i + 1.0;
     }
     auto t1 = std::chrono::high_resolution_clock::now();
     for (int it = 0; it < times; ++it) {
       if (FHTDouble(a, n, chunk) == -1) {
-	throw std::runtime_error("error in FHT");
+        throw std::runtime_error("error in FHT");
       }
     }
     auto t2 = std::chrono::high_resolution_clock::now();
     free(a);
-    return std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count();
-  }
-  else {
+    return std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1)
+        .count();
+  } else {
     float *a;
     void *aux;
     int res = posix_memalign(&aux, 32, std::max(n, 32) * sizeof(float));
     if (res) {
       throw std::runtime_error("error in posix_memalign");
     }
-    a = (float*)aux;
+    a = (float *)aux;
     for (int i = 0; i < n; ++i) {
       a[i] = i + 1.0;
     }
     auto t1 = std::chrono::high_resolution_clock::now();
     for (int it = 0; it < times; ++it) {
       if (FHTFloat(a, n, chunk) == -1) {
-	throw std::runtime_error("error in FHT");
+        throw std::runtime_error("error in FHT");
       }
     }
     auto t2 = std::chrono::high_resolution_clock::now();
     free(a);
-    return std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count();
+    return std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1)
+        .count();
   }
 }
 
@@ -78,36 +79,33 @@ int main() {
     for (int it = 0; it < 2; ++it) {
       bool isDouble = (bool)it;
       std::cout << "determining the best chunk size for "
-		<< ((isDouble) ? "double" : "float")
-		<< std::endl;
+                << ((isDouble) ? "double" : "float") << std::endl;
       int chunk = 8;
       std::map<int, double> data;
       for (;;) {
-	std::cout << "chunk size " << chunk << ": ";
-	data[chunk] = measureTime(n, chunk, isDouble);
-	std::cout << data[chunk] << std::endl;
-	if (chunk >= n) {
-	  break;
-	}
-	chunk *= 2;
+        std::cout << "chunk size " << chunk << ": ";
+        data[chunk] = measureTime(n, chunk, isDouble);
+        std::cout << data[chunk] << std::endl;
+        if (chunk >= n) {
+          break;
+        }
+        chunk *= 2;
       }
       int best_chunk = -1;
       double best_time = 1e100;
       for (auto it = data.begin(); it != data.end(); ++it) {
-	if (it->second < best_time) {
-	  best_time = it->second;
-	  best_chunk = it->first;
-	}
+        if (it->second < best_time) {
+          best_time = it->second;
+          best_chunk = it->first;
+        }
       }
       std::cout << "best chunk: " << best_chunk << std::endl;
       std::cout << "best time: " << best_time << std::endl;
     }
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     std::cerr << e.what() << std::endl;
     return 1;
-  }
-  catch (...) {
+  } catch (...) {
     std::cerr << "ERROR" << std::endl;
     return 1;
   }

--- a/src/include/falconn/ffht/example.py
+++ b/src/include/falconn/ffht/example.py
@@ -13,4 +13,4 @@ t1 = timeit.default_timer()
 for i in range(reps):
     ffht.fht(a, chunk_size)
 t2 = timeit.default_timer()
-print (t2 - t1 + 0.0) / (reps + 0.0)
+print(t2 - t1 + 0.0) / (reps + 0.0)

--- a/src/include/falconn/ffht/ffht/__init__.py
+++ b/src/include/falconn/ffht/ffht/__init__.py
@@ -13,6 +13,7 @@ implementation of *any* Fourier-like transform.
 from _ffht import fht
 import numpy as _numpy
 
+
 def create_aligned(n, dtype, alignment=32):
     """ Create an aligned one-dimensional NumPy array.
 
@@ -28,4 +29,4 @@ def create_aligned(n, dtype, alignment=32):
     shift = 0
     if off != 0:
         shift = (alignment - off) / buf.itemsize
-    return buf[shift : shift + n]
+    return buf[shift:shift + n]

--- a/src/include/falconn/ffht/setup.py
+++ b/src/include/falconn/ffht/setup.py
@@ -3,7 +3,7 @@ import sys
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
-except(IOError, ImportError):
+except (IOError, ImportError):
     long_description = open('README.md').read()
 
 try:
@@ -18,23 +18,26 @@ except ImportError:
     sys.stderr.write('NumPy not found!\n')
     raise
 
-module = Extension('_ffht',
-                   sources=['_ffht.c', 'fht.c'],
-                   extra_compile_args=['-march=native', '-O3', '-Wall', '-Wextra', '-pedantic',
-                                       '-Wshadow', '-Wpointer-arith', '-Wcast-qual',
-                                       '-Wstrict-prototypes', '-Wmissing-prototypes',
-                                       '-std=c99'],
-                   include_dirs=[np.get_include()])
+module = Extension(
+    '_ffht',
+    sources=['_ffht.c', 'fht.c'],
+    extra_compile_args=[
+        '-march=native', '-O3', '-Wall', '-Wextra', '-pedantic', '-Wshadow',
+        '-Wpointer-arith', '-Wcast-qual', '-Wstrict-prototypes',
+        '-Wmissing-prototypes', '-std=c99'
+    ],
+    include_dirs=[np.get_include()])
 
-setup(name='FFHT',
-      version='1.0',
-      author='Ilya Razenshteyn, Ludwig Schmidt',
-      author_email='falconn.lib@gmail.com',
-      url='https://github.com/FALCONN-LIB/FFHT',
-      description='Fast implementation of the Fast Hadamard Transform (FHT)',
-      long_description=long_description,
-      license='MIT',
-      keywords='fast Fourier Hadamard transform butterfly',
-      packages=find_packages(),
-      include_package_data=True,
-      ext_modules=[module])
+setup(
+    name='FFHT',
+    version='1.0',
+    author='Ilya Razenshteyn, Ludwig Schmidt',
+    author_email='falconn.lib@gmail.com',
+    url='https://github.com/FALCONN-LIB/FFHT',
+    description='Fast implementation of the Fast Hadamard Transform (FHT)',
+    long_description=long_description,
+    license='MIT',
+    keywords='fast Fourier Hadamard transform butterfly',
+    packages=find_packages(),
+    include_package_data=True,
+    ext_modules=[module])

--- a/src/include/falconn/ffht/test.cpp
+++ b/src/include/falconn/ffht/test.cpp
@@ -6,7 +6,8 @@
 
 #include <cstdlib>
 
-template<typename T> void referenceFHTHelper(T *buffer, int len) {
+template <typename T>
+void referenceFHTHelper(T *buffer, int len) {
   if (len == 1) {
     return;
   }
@@ -21,7 +22,8 @@ template<typename T> void referenceFHTHelper(T *buffer, int len) {
   }
 }
 
-template<typename T> void referenceFHT(T *buffer, int len) {
+template <typename T>
+void referenceFHT(T *buffer, int len) {
   if (len < 1 || (len & (len - 1))) {
     throw std::runtime_error("invalid length in the model FFT");
   }
@@ -40,7 +42,7 @@ void testFloat(int n, int chunk) {
   if (res) {
     throw std::runtime_error("error in posix_memalign");
   }
-  a = (float*)aux;
+  a = (float *)aux;
   for (int i = 0; i < n; ++i) {
     a[i] = sqrt(i + 0.0);
   }
@@ -64,7 +66,7 @@ void testDouble(int n, int chunk) {
   if (res) {
     throw std::runtime_error("error in posix_memalign");
   }
-  a = (double*)aux;
+  a = (double *)aux;
   for (int i = 0; i < n; ++i) {
     a[i] = sqrt(i + 0.0);
   }
@@ -85,20 +87,18 @@ int main() {
     for (int n = 1; n <= (1 << 20); n *= 2) {
       int chunk = 8;
       for (;;) {
-	testFloat(n, chunk);
-	testDouble(n, chunk);
-	if (chunk > n) {
-	  break;
-	}
-	chunk *= 2;
+        testFloat(n, chunk);
+        testDouble(n, chunk);
+        if (chunk > n) {
+          break;
+        }
+        chunk *= 2;
       }
     }
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     std::cerr << e.what() << std::endl;
     return 1;
-  }
-  catch (...) {
+  } catch (...) {
     std::cerr << "ERROR" << std::endl;
     return 1;
   }

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -86,7 +86,7 @@ template <typename PointType, typename KeyType = int32_t>
 class LSHNearestNeighborTable {
  public:
   virtual std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>>
-  construct_query() const = 0;
+  construct_query_processor() const = 0;
   ///
   /// Sets the number of probes used for each query.
   /// The default setting is l (number of tables), which effectively disables

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -85,7 +85,7 @@ template <typename PointType, typename KeyType = int32_t>
 class LSHNearestNeighborTable {
  public:
   virtual std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>>
-  construct_query_processor() const = 0;
+  construct_query_object() const = 0;
   ///
   /// Sets the number of probes used for each query.
   /// The default setting is l (number of tables), which effectively disables

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -217,6 +217,13 @@ class LSHNearestNeighborTable {
   /// This function constructs a new query object. The query object holds
   /// all per-query state and executes table lookups.
   ///
+  /// num_probes == -1 (the default value) indicates that the number of probes
+  /// should equal the number of tables. This corresponds to no multiprobe.
+  ///
+  /// max_num_candidates == -1 (the default value) indicates that the number of
+  /// candidates should not be limited. This means that the entire probing
+  /// sequence is used.
+  ///
   virtual std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>>
   construct_query_object(int_fast64_t num_probes = -1,
                          int_fast64_t max_num_candidates = -1) const = 0;
@@ -226,10 +233,23 @@ class LSHNearestNeighborTable {
   /// a set of query objects and supports an interface that can be safely
   /// called from multiple threads.
   ///
+  /// num_probes == -1 (the default value) indicates that the number of probes
+  /// should equal the number of tables. This corresponds to no multiprobe.
+  ///
+  /// max_num_candidates == -1 (the default value) indicates that the number of
+  /// candidates should not be limited. This means that the entire probing
+  /// sequence is used.
+  ///
+  /// num_query_objects <= 0 (the default value) indicates that the number of
+  /// query objects should be 2 times the number of hardware threads (as
+  /// indicated by std::thread:hardware_concurrency()). This is a reasonable
+  /// default for thread pools etc. that do not use an excessive number of
+  /// threads.
+  ///
   virtual std::unique_ptr<LSHNearestNeighborQueryPool<PointType, KeyType>>
   construct_query_pool(int_fast64_t num_probes = -1,
                        int_fast64_t max_num_candidates = -1,
-                       int_fast64_t num_query_objects = -1) const = 0;
+                       int_fast64_t num_query_objects = 0) const = 0;
 
   ///
   /// Virtual destructor.

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -24,9 +24,8 @@ class LSHNearestNeighborTableError : public FalconnError {
   LSHNearestNeighborTableError(const char* msg) : FalconnError(msg) {}
 };
 
-// Common interface for query
-// which doesn't change the state of LSHNearestNeighborTable
-// and can be quiqly created for each thread
+// A common interface for query objects that do not change the state of
+// LSHNearestNeighborTable and can be quickly created for each thread.
 
 template <typename PointType, typename KeyType = int32_t>
 class LSHNearestNeighborQuery {

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -24,6 +24,35 @@ class LSHNearestNeighborTableError : public FalconnError {
   LSHNearestNeighborTableError(const char* msg) : FalconnError(msg) {}
 };
 
+
+//Common interface for query
+//which doesn't change the state of LSHNearestNeighborTable
+//and can be quiqly created for each thread
+
+template <typename PointType, typename KeyType = int32_t>
+class LSHNearestNeighborQuery{
+ public:
+    ///
+    /// Returns the keys of all candidates in the probing sequence for q.
+    /// Every candidate key occurs only once in the result. The
+    /// candidates are returned in the order of their first occurrence in the
+    /// probing sequence.
+    ///
+    virtual void get_unique_candidates(const PointType& q,
+                                       std::vector<KeyType>* result) = 0;
+
+    ///
+    /// Returns the keys of all candidates in the probing sequence for q. If a
+    /// candidate key is found in multiple tables, it will appear multiple times
+    /// in the result. The candidates are returned in the order in which they
+    /// appear in the probing sequence.
+    ///
+    virtual void get_candidates_with_duplicates(const PointType& q,
+                                                std::vector<KeyType>* result) = 0;
+
+    virtual ~LSHNearestNeighborQuery() {}
+};
+
 ///
 /// Common interface shared by all LSH table wrappers.
 ///
@@ -36,6 +65,10 @@ class LSHNearestNeighborTableError : public FalconnError {
 template <typename PointType, typename KeyType = int32_t>
 class LSHNearestNeighborTable {
  public:
+
+  ///Create a new query that doesn't chage the parent object LSHNearestNeighborTable
+  virtual std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>> construct_query() const = 0;
+
   ///
   /// Sets the number of probes used for each query.
   /// The default setting is l (number of tables), which effectively disables

--- a/src/include/falconn/lsh_nn_table.h
+++ b/src/include/falconn/lsh_nn_table.h
@@ -56,7 +56,7 @@ class LSHNearestNeighborQuery {
   /// Returns the maximum number of candidates considered in each query.
   ///
   virtual int_fast64_t get_max_num_candidates() = 0;
-  
+
   ///
   /// Finds the key of the closest candidate in the probing sequence for q.
   ///
@@ -95,7 +95,7 @@ class LSHNearestNeighborQuery {
   ///
   virtual void get_candidates_with_duplicates(const PointType& q,
                                               std::vector<KeyType>* result) = 0;
-  
+
   ///
   /// Resets the query statistics.
   ///
@@ -108,7 +108,6 @@ class LSHNearestNeighborQuery {
   /// time be averaged over all queries or only the near(est) neighbor queries?
   ///
   virtual QueryStatistics get_query_statistics() = 0;
-
 
   virtual ~LSHNearestNeighborQuery() {}
 };
@@ -144,7 +143,7 @@ class LSHNearestNeighborQueryPool {
   /// Returns the maximum number of candidates considered in each query.
   ///
   virtual int_fast64_t get_max_num_candidates() = 0;
-  
+
   ///
   /// Finds the key of the closest candidate in the probing sequence for q.
   ///
@@ -179,7 +178,7 @@ class LSHNearestNeighborQueryPool {
   ///
   virtual void get_candidates_with_duplicates(const PointType& q,
                                               std::vector<KeyType>* result) = 0;
-  
+
   ///
   /// Resets the query statistics.
   ///
@@ -190,7 +189,6 @@ class LSHNearestNeighborQueryPool {
   /// See the documentation for LSHNearestNeighborQuery.
   ///
   virtual QueryStatistics get_query_statistics() = 0;
-
 
   virtual ~LSHNearestNeighborQueryPool() {}
 };
@@ -212,7 +210,7 @@ class LSHNearestNeighborTable {
   /// equivalent to infinity.
   ///
   static const int_fast64_t kNoMaxNumCandidates = -1;
- 
+
   ///
   /// This function constructs a new query object. The query object holds
   /// all per-query state and executes table lookups.
@@ -227,7 +225,7 @@ class LSHNearestNeighborTable {
   virtual std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>>
   construct_query_object(int_fast64_t num_probes = -1,
                          int_fast64_t max_num_candidates = -1) const = 0;
-  
+
   ///
   /// This function constructs a new query pool. The query pool holds
   /// a set of query objects and supports an interface that can be safely

--- a/src/include/falconn/wrapper/cpp_wrapper_impl.h
+++ b/src/include/falconn/wrapper/cpp_wrapper_impl.h
@@ -393,7 +393,7 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
     num_probes_ = lsh_->get_l();
   }
 
-  std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>> construct_query_processor()
+  std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>> construct_query_object()
       const {
     typedef typename PointTypeTraits<PointType>::ScalarType ScalarType;
     std::unique_ptr<

--- a/src/include/falconn/wrapper/cpp_wrapper_impl.h
+++ b/src/include/falconn/wrapper/cpp_wrapper_impl.h
@@ -360,9 +360,8 @@ class LSHNNQueryWrapper : public LSHNearestNeighborQuery<PointType, KeyType> {
 
   void get_candidates_with_duplicates(const PointType& q,
                                       std::vector<KeyType>* result) {
-    internal_nn_query_->get_candidates_with_duplicates(q, num_probes_,
-                                                       max_num_candidates_,
-                                                       result);
+    internal_nn_query_->get_candidates_with_duplicates(
+        q, num_probes_, max_num_candidates_, result);
   }
 
   void get_unique_candidates(const PointType& q, std::vector<KeyType>* result) {
@@ -370,9 +369,7 @@ class LSHNNQueryWrapper : public LSHNearestNeighborQuery<PointType, KeyType> {
                                               max_num_candidates_, result);
   }
 
-  int_fast64_t get_num_probes() {
-    return num_probes_;
-  }
+  int_fast64_t get_num_probes() { return num_probes_; }
 
   void set_num_probes(int_fast64_t new_num_probes) {
     if (new_num_probes <= 0) {
@@ -382,14 +379,12 @@ class LSHNNQueryWrapper : public LSHNearestNeighborQuery<PointType, KeyType> {
     num_probes_ = new_num_probes;
   }
 
-  int_fast64_t get_max_num_candidates() {
-    return max_num_candidates_;
-  }
+  int_fast64_t get_max_num_candidates() { return max_num_candidates_; }
 
   void set_max_num_candidates(int_fast64_t new_max_num_candidates) {
     max_num_candidates_ = new_max_num_candidates;
   }
-  
+
   void reset_query_statistics() {
     internal_nn_query_->reset_query_statistics();
   }
@@ -410,15 +405,14 @@ class LSHNNQueryWrapper : public LSHNearestNeighborQuery<PointType, KeyType> {
 template <typename PointType, typename KeyType, typename DistanceType,
           typename LSHTable, typename ScalarType, typename DistanceFunction,
           typename DataStorage>
-class LSHNNQueryPool: public LSHNearestNeighborQueryPool<PointType, KeyType> {
+class LSHNNQueryPool : public LSHNearestNeighborQueryPool<PointType, KeyType> {
   typedef core::NearestNeighborQuery<typename LSHTable::Query, PointType,
                                      KeyType, PointType, ScalarType,
                                      DistanceFunction, DataStorage>
       NNQueryType;
 
  public:
-  LSHNNQueryPool(const LSHTable& parent,
-                 int_fast64_t num_probes,
+  LSHNNQueryPool(const LSHTable& parent, int_fast64_t num_probes,
                  int_fast64_t max_num_candidates,
                  const DataStorage& data_storage,
                  int_fast64_t num_query_objects)
@@ -483,9 +477,7 @@ class LSHNNQueryPool: public LSHNearestNeighborQueryPool<PointType, KeyType> {
     unlock_query(query_index);
   }
 
-  int_fast64_t get_num_probes() {
-    return num_probes_;
-  }
+  int_fast64_t get_num_probes() { return num_probes_; }
 
   void set_num_probes(int_fast64_t new_num_probes) {
     if (new_num_probes <= 0) {
@@ -495,18 +487,17 @@ class LSHNNQueryPool: public LSHNearestNeighborQueryPool<PointType, KeyType> {
     num_probes_ = new_num_probes;
   }
 
-  int_fast64_t get_max_num_candidates() {
-    return max_num_candidates_;
-  }
+  int_fast64_t get_max_num_candidates() { return max_num_candidates_; }
 
   void set_max_num_candidates(int_fast64_t new_max_num_candidates) {
     max_num_candidates_ = new_max_num_candidates;
   }
-  
+
   void reset_query_statistics() {
-    for (int_fast64_t ii = 0; ii < static_cast<int_fast64_t>(
-         internal_nn_queries_.size()); ++ii) {
-      while (locks_[ii].test_and_set(std::memory_order_acquire)) ;
+    for (int_fast64_t ii = 0;
+         ii < static_cast<int_fast64_t>(internal_nn_queries_.size()); ++ii) {
+      while (locks_[ii].test_and_set(std::memory_order_acquire))
+        ;
       internal_nn_queries_[ii]->reset_query_statistics();
       locks_[ii].clear(std::memory_order_release);
     }
@@ -514,9 +505,10 @@ class LSHNNQueryPool: public LSHNearestNeighborQueryPool<PointType, KeyType> {
 
   QueryStatistics get_query_statistics() {
     QueryStatistics res;
-    for (int_fast64_t ii = 0; ii < static_cast<int_fast64_t>(
-         internal_nn_queries_.size()); ++ii) {
-      while (locks_[ii].test_and_set(std::memory_order_acquire)) ;
+    for (int_fast64_t ii = 0;
+         ii < static_cast<int_fast64_t>(internal_nn_queries_.size()); ++ii) {
+      while (locks_[ii].test_and_set(std::memory_order_acquire))
+        ;
       QueryStatistics cur_stats =
           internal_nn_queries_[ii]->get_query_statistics();
       cur_stats.convert_to_totals();
@@ -574,8 +566,9 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
         composite_hash_table_(std::move(composite_hash_table)),
         data_storage_(std::move(data_storage)) {}
 
-  std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>> construct_query_object(int_fast64_t num_probes = -1,
-      int_fast64_t max_num_candidates = -1) const {
+  std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>>
+  construct_query_object(int_fast64_t num_probes = -1,
+                         int_fast64_t max_num_candidates = -1) const {
     if (num_probes <= 0) {
       num_probes = lsh_->get_l();
     }
@@ -589,11 +582,11 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
                 *lsh_table_, num_probes, max_num_candidates, *data_storage_));
     return std::move(nn_query);
   }
-  
+
   std::unique_ptr<LSHNearestNeighborQueryPool<PointType, KeyType>>
-      construct_query_pool(int_fast64_t num_probes = -1,
-                           int_fast64_t max_num_candidates = -1,
-                           int_fast64_t num_query_objects = -1) const {
+  construct_query_pool(int_fast64_t num_probes = -1,
+                       int_fast64_t max_num_candidates = -1,
+                       int_fast64_t num_query_objects = -1) const {
     if (num_probes <= 0) {
       num_probes = lsh_->get_l();
     }
@@ -601,9 +594,8 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
       num_query_objects = std::max(1u, 2 * std::thread::hardware_concurrency());
     }
     typedef typename PointTypeTraits<PointType>::ScalarType ScalarType;
-    std::unique_ptr<
-        LSHNNQueryPool<PointType, KeyType, DistanceType, LSHTable,
-                       ScalarType, DistanceFunction, DataStorage>>
+    std::unique_ptr<LSHNNQueryPool<PointType, KeyType, DistanceType, LSHTable,
+                                   ScalarType, DistanceFunction, DataStorage>>
         nn_query_pool(
             new LSHNNQueryPool<PointType, KeyType, DistanceType, LSHTable,
                                ScalarType, DistanceFunction, DataStorage>(
@@ -853,13 +845,12 @@ class StaticTableFactory {
         new LSHTableType(lsh.get(), composite_table.get(), *data_storage_,
                          params_.num_setup_threads));
 
-    table_.reset(
-        new LSHNNTableWrapper<PointType, KeyType, ScalarType,
-                              DistanceFunctionType, LSHTableType, LSHType,
-                              HashTableFactoryType, CompositeHashTableType,
-                              DataStorageType>(
-            std::move(lsh), std::move(lsh_table), std::move(factory),
-            std::move(composite_table), std::move(data_storage_)));
+    table_.reset(new LSHNNTableWrapper<PointType, KeyType, ScalarType,
+                                       DistanceFunctionType, LSHTableType,
+                                       LSHType, HashTableFactoryType,
+                                       CompositeHashTableType, DataStorageType>(
+        std::move(lsh), std::move(lsh_table), std::move(factory),
+        std::move(composite_table), std::move(data_storage_)));
   }
 
   const static int_fast32_t kHashTypeIndex = 0;

--- a/src/include/falconn/wrapper/cpp_wrapper_impl.h
+++ b/src/include/falconn/wrapper/cpp_wrapper_impl.h
@@ -393,7 +393,7 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
     num_probes_ = lsh_->get_l();
   }
 
-  std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>> construct_query()
+  std::unique_ptr<LSHNearestNeighborQuery<PointType, KeyType>> construct_query_processor()
       const {
     typedef typename PointTypeTraits<PointType>::ScalarType ScalarType;
     std::unique_ptr<

--- a/src/include/falconn/wrapper/cpp_wrapper_impl.h
+++ b/src/include/falconn/wrapper/cpp_wrapper_impl.h
@@ -1,6 +1,9 @@
 #ifndef __CPP_WRAPPER_IMPL_H__
 #define __CPP_WRAPPER_IMPL_H__
 
+#include <atomic>
+#include <random>
+#include <thread>
 #include <type_traits>
 
 #include "../core/bit_packed_flat_hash_table.h"
@@ -325,45 +328,50 @@ class LSHNNQueryWrapper : public LSHNearestNeighborQuery<PointType, KeyType> {
       NNQueryType;
 
  public:
-  LSHNNQueryWrapper(const LSHTable& parent, int_fast64_t _num_probes,
-                    int_fast64_t _max_candidates,
+  LSHNNQueryWrapper(const LSHTable& parent, int_fast64_t num_probes,
+                    int_fast64_t max_num_candidates,
                     const DataStorage& data_storage)
-      : num_probes(_num_probes), max_num_candidates(_max_candidates) {
-    internal_query.reset(new typename LSHTable::Query(parent));
-    internal_nn_query.reset(
-        new NNQueryType(internal_query.get(), data_storage));
+      : num_probes_(num_probes), max_num_candidates_(max_num_candidates) {
+    if (num_probes <= 0) {
+      throw LSHNearestNeighborTableError(
+          "Number of probes must be at least 1.");
+    }
+    internal_query_.reset(new typename LSHTable::Query(parent));
+    internal_nn_query_.reset(
+        new NNQueryType(internal_query_.get(), data_storage));
   }
 
   KeyType find_nearest_neighbor(const PointType& q) {
-    return internal_nn_query->find_nearest_neighbor(q, q, num_probes,
-                                                    max_num_candidates);
+    return internal_nn_query_->find_nearest_neighbor(q, q, num_probes_,
+                                                     max_num_candidates_);
   }
 
   void find_k_nearest_neighbors(const PointType& q, int_fast64_t k,
                                 std::vector<KeyType>* result) {
-    internal_nn_query->find_k_nearest_neighbors(q, q, k, num_probes,
-                                                max_num_candidates, result);
+    internal_nn_query_->find_k_nearest_neighbors(q, q, k, num_probes_,
+                                                 max_num_candidates_, result);
   }
 
   void find_near_neighbors(const PointType& q, DistanceType threshold,
                            std::vector<KeyType>* result) {
-    internal_nn_query->find_near_neighbors(q, q, threshold, num_probes,
-                                           max_num_candidates, result);
+    internal_nn_query_->find_near_neighbors(q, q, threshold, num_probes_,
+                                            max_num_candidates_, result);
   }
 
   void get_candidates_with_duplicates(const PointType& q,
                                       std::vector<KeyType>* result) {
-    internal_query->get_candidates_with_duplicates(q, num_probes,
-                                                   max_num_candidates, result);
+    internal_nn_query_->get_candidates_with_duplicates(q, num_probes_,
+                                                       max_num_candidates_,
+                                                       result);
   }
 
   void get_unique_candidates(const PointType& q, std::vector<KeyType>* result) {
-    return internal_query->get_unique_candidates(q, num_probes,
-                                                 max_num_candidates, result);
+    internal_nn_query_->get_unique_candidates(q, num_probes_,
+                                              max_num_candidates_, result);
   }
 
   int_fast64_t get_num_probes() {
-    return num_probes;
+    return num_probes_;
   }
 
   void set_num_probes(int_fast64_t new_num_probes) {
@@ -371,32 +379,182 @@ class LSHNNQueryWrapper : public LSHNearestNeighborQuery<PointType, KeyType> {
       throw LSHNearestNeighborTableError(
           "Number of probes must be at least 1.");
     }
-    num_probes = new_num_probes;
+    num_probes_ = new_num_probes;
   }
 
   int_fast64_t get_max_num_candidates() {
-    return max_num_candidates;
+    return max_num_candidates_;
   }
 
   void set_max_num_candidates(int_fast64_t new_max_num_candidates) {
-    max_num_candidates = new_max_num_candidates;
+    max_num_candidates_ = new_max_num_candidates;
   }
   
   void reset_query_statistics() {
-    internal_nn_query->reset_query_statistics();
+    internal_nn_query_->reset_query_statistics();
   }
 
   QueryStatistics get_query_statistics() {
-    return internal_nn_query->get_query_statistics();
+    return internal_nn_query_->get_query_statistics();
   }
 
   virtual ~LSHNNQueryWrapper() {}
 
  protected:
-  std::unique_ptr<typename LSHTable::Query> internal_query;
-  std::unique_ptr<NNQueryType> internal_nn_query;
-  int_fast64_t num_probes;
-  int_fast64_t max_num_candidates;
+  std::unique_ptr<typename LSHTable::Query> internal_query_;
+  std::unique_ptr<NNQueryType> internal_nn_query_;
+  int_fast64_t num_probes_;
+  int_fast64_t max_num_candidates_;
+};
+
+template <typename PointType, typename KeyType, typename DistanceType,
+          typename LSHTable, typename ScalarType, typename DistanceFunction,
+          typename DataStorage>
+class LSHNNQueryPool: public LSHNearestNeighborQueryPool<PointType, KeyType> {
+  typedef core::NearestNeighborQuery<typename LSHTable::Query, PointType,
+                                     KeyType, PointType, ScalarType,
+                                     DistanceFunction, DataStorage>
+      NNQueryType;
+
+ public:
+  LSHNNQueryPool(const LSHTable& parent,
+                 int_fast64_t num_probes,
+                 int_fast64_t max_num_candidates,
+                 const DataStorage& data_storage,
+                 int_fast64_t num_query_objects)
+      : locks_(num_query_objects),
+        num_probes_(num_probes),
+        max_num_candidates_(max_num_candidates) {
+    if (num_probes <= 0) {
+      throw LSHNearestNeighborTableError(
+          "Number of probes must be at least 1.");
+    }
+    if (num_query_objects <= 0) {
+      throw LSHNearestNeighborTableError(
+          "Number of query objects in the pool must be at least 1.");
+    }
+    for (int ii = 0; ii < num_query_objects; ++ii) {
+      std::unique_ptr<typename LSHTable::Query> cur_query(
+          new typename LSHTable::Query(parent));
+      std::unique_ptr<NNQueryType> cur_nn_query(
+          new NNQueryType(cur_query.get(), data_storage));
+      internal_queries_.push_back(std::move(cur_query));
+      internal_nn_queries_.push_back(std::move(cur_nn_query));
+      locks_[ii].clear(std::memory_order_release);
+    }
+  }
+
+  KeyType find_nearest_neighbor(const PointType& q) {
+    int_fast32_t query_index = get_query_index_and_lock();
+    KeyType res = internal_nn_queries_[query_index]->find_nearest_neighbor(
+        q, q, num_probes_, max_num_candidates_);
+    unlock_query(query_index);
+    return res;
+  }
+
+  void find_k_nearest_neighbors(const PointType& q, int_fast64_t k,
+                                std::vector<KeyType>* result) {
+    int_fast32_t query_index = get_query_index_and_lock();
+    internal_nn_queries_[query_index]->find_k_nearest_neighbors(
+        q, q, k, num_probes_, max_num_candidates_, result);
+    unlock_query(query_index);
+  }
+
+  void find_near_neighbors(const PointType& q, DistanceType threshold,
+                           std::vector<KeyType>* result) {
+    int_fast32_t query_index = get_query_index_and_lock();
+    internal_nn_queries_[query_index]->find_near_neighbors(
+        q, q, threshold, num_probes_, max_num_candidates_, result);
+    unlock_query(query_index);
+  }
+
+  void get_candidates_with_duplicates(const PointType& q,
+                                      std::vector<KeyType>* result) {
+    int_fast32_t query_index = get_query_index_and_lock();
+    internal_nn_queries_[query_index]->get_candidates_with_duplicates(
+        q, num_probes_, max_num_candidates_, result);
+    unlock_query(query_index);
+  }
+
+  void get_unique_candidates(const PointType& q, std::vector<KeyType>* result) {
+    int_fast32_t query_index = get_query_index_and_lock();
+    internal_nn_queries_[query_index]->get_unique_candidates(
+        q, num_probes_, max_num_candidates_, result);
+    unlock_query(query_index);
+  }
+
+  int_fast64_t get_num_probes() {
+    return num_probes_;
+  }
+
+  void set_num_probes(int_fast64_t new_num_probes) {
+    if (new_num_probes <= 0) {
+      throw LSHNearestNeighborTableError(
+          "Number of probes must be at least 1.");
+    }
+    num_probes_ = new_num_probes;
+  }
+
+  int_fast64_t get_max_num_candidates() {
+    return max_num_candidates_;
+  }
+
+  void set_max_num_candidates(int_fast64_t new_max_num_candidates) {
+    max_num_candidates_ = new_max_num_candidates;
+  }
+  
+  void reset_query_statistics() {
+    for (int_fast64_t ii = 0; ii < static_cast<int_fast64_t>(
+         internal_nn_queries_.size()); ++ii) {
+      while (locks_[ii].test_and_set(std::memory_order_acquire)) ;
+      internal_nn_queries_[ii]->reset_query_statistics();
+      locks_[ii].clear(std::memory_order_release);
+    }
+  }
+
+  QueryStatistics get_query_statistics() {
+    QueryStatistics res;
+    for (int_fast64_t ii = 0; ii < static_cast<int_fast64_t>(
+         internal_nn_queries_.size()); ++ii) {
+      while (locks_[ii].test_and_set(std::memory_order_acquire)) ;
+      QueryStatistics cur_stats =
+          internal_nn_queries_[ii]->get_query_statistics();
+      cur_stats.convert_to_totals();
+      res.add_totals(cur_stats);
+      locks_[ii].clear(std::memory_order_release);
+    }
+    res.compute_averages();
+    return res;
+  }
+
+  virtual ~LSHNNQueryPool() {}
+
+ protected:
+  int_fast32_t get_query_index_and_lock() {
+    static thread_local std::minstd_rand gen((std::random_device())());
+    std::uniform_int_distribution<int_fast32_t> dist(0, locks_.size() - 1);
+    int_fast32_t cur_index = dist(gen);
+    while (true) {
+      if (!locks_[cur_index].test_and_set(std::memory_order_acquire)) {
+        return cur_index;
+      }
+      if (cur_index == static_cast<int_fast32_t>(locks_.size()) - 1) {
+        cur_index = 0;
+      } else {
+        cur_index += 1;
+      }
+    }
+  }
+
+  void unlock_query(int_fast32_t index) {
+    locks_[index].clear(std::memory_order_release);
+  }
+
+  std::vector<std::unique_ptr<typename LSHTable::Query>> internal_queries_;
+  std::vector<std::unique_ptr<NNQueryType>> internal_nn_queries_;
+  std::vector<std::atomic_flag> locks_;
+  int_fast64_t num_probes_;
+  int_fast64_t max_num_candidates_;
 };
 
 template <typename PointType, typename KeyType, typename DistanceType,
@@ -430,6 +588,28 @@ class LSHNNTableWrapper : public LSHNearestNeighborTable<PointType, KeyType> {
                                   ScalarType, DistanceFunction, DataStorage>(
                 *lsh_table_, num_probes, max_num_candidates, *data_storage_));
     return std::move(nn_query);
+  }
+  
+  std::unique_ptr<LSHNearestNeighborQueryPool<PointType, KeyType>>
+      construct_query_pool(int_fast64_t num_probes = -1,
+                           int_fast64_t max_num_candidates = -1,
+                           int_fast64_t num_query_objects = -1) const {
+    if (num_probes <= 0) {
+      num_probes = lsh_->get_l();
+    }
+    if (num_query_objects <= 0) {
+      num_query_objects = std::max(1u, 2 * std::thread::hardware_concurrency());
+    }
+    typedef typename PointTypeTraits<PointType>::ScalarType ScalarType;
+    std::unique_ptr<
+        LSHNNQueryPool<PointType, KeyType, DistanceType, LSHTable,
+                       ScalarType, DistanceFunction, DataStorage>>
+        nn_query_pool(
+            new LSHNNQueryPool<PointType, KeyType, DistanceType, LSHTable,
+                               ScalarType, DistanceFunction, DataStorage>(
+                *lsh_table_, num_probes, max_num_candidates, *data_storage_,
+                num_query_objects));
+    return std::move(nn_query_pool);
   }
 
   ~LSHNNTableWrapper() {}

--- a/src/micro-benchmarks/distance_computation.cpp
+++ b/src/micro-benchmarks/distance_computation.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <Eigen/Dense>
+#include <iostream>
 
 #include <chrono>
 #include <random>
@@ -26,12 +26,12 @@ using std::chrono::duration_cast;
 using Eigen::VectorXf;
 using Eigen::Map;
 
-void worker(float *dataset,
-	    float *query,
-	    const vector<int> &candidates, int d, int u, int v, float *dummy) {
+void worker(float *dataset, float *query, const vector<int> &candidates, int d,
+            int u, int v, float *dummy) {
   *dummy = 0.0;
   for (int i = u; i < v; ++i) {
-    *dummy += Map<VectorXf>(dataset + candidates[i] * d, d).dot(Map<VectorXf>(query, d));
+    *dummy += Map<VectorXf>(dataset + candidates[i] * d, d)
+                  .dot(Map<VectorXf>(query, d));
   }
 }
 
@@ -45,7 +45,7 @@ int main() {
   int max_num_threads = thread::hardware_concurrency();
   cout << max_num_threads << " threads are supported" << endl;
   float *dataset;
-  if (posix_memalign((void**)&dataset, 32, sizeof(float) * N * D)) {
+  if (posix_memalign((void **)&dataset, 32, sizeof(float) * N * D)) {
     throw runtime_error("can't allocate memory for dataset");
   }
   random_device rd;
@@ -61,7 +61,8 @@ int main() {
   }
   for (int num_threads = 1; num_threads <= max_num_threads; ++num_threads) {
     float *queries;
-    if (posix_memalign((void**)&queries, 32, sizeof(float) * D * num_threads)) {
+    if (posix_memalign((void **)&queries, 32,
+                       sizeof(float) * D * num_threads)) {
       throw runtime_error("can't allocate memory for queries");
     }
     for (int i = 0; i < num_threads * D; ++i) {
@@ -73,7 +74,7 @@ int main() {
       int cnt = Q / num_threads;
       int rem = Q % num_threads;
       if (i < rem) {
-	++cnt;
+        ++cnt;
       }
       start[i + 1] = start[i] + cnt;
     }
@@ -81,19 +82,16 @@ int main() {
     vector<thread> threads;
     auto t1 = high_resolution_clock::now();
     for (int i = 0; i < num_threads; ++i) {
-      threads.push_back(thread(worker, dataset, queries + i * D, candidates, D, start[i], start[i + 1], &dummy[i]));
+      threads.push_back(thread(worker, dataset, queries + i * D, candidates, D,
+                               start[i], start[i + 1], &dummy[i]));
     }
     for (int i = 0; i < num_threads; ++i) {
       threads[i].join();
     }
     auto t2 = high_resolution_clock::now();
-    cout << num_threads
-	 << " thread"
-	 << ((num_threads > 1) ? "s" : "")
-	 << ": "
-	 << duration_cast<duration<double>>(t2 - t1).count()
-	 << " seconds"
-	 << endl;
+    cout << num_threads << " thread" << ((num_threads > 1) ? "s" : "") << ": "
+         << duration_cast<duration<double>>(t2 - t1).count() << " seconds"
+         << endl;
     free(queries);
   }
   free(dataset);

--- a/src/python/benchmark/random_benchmark.py
+++ b/src/python/benchmark/random_benchmark.py
@@ -11,13 +11,13 @@ sys.path.append('python_swig')
 
 import falconn
 
-def run_experiment(table, queries, true_nns):
+def run_experiment(query_obj, queries, true_nns):
   average_query_time_outside = 0.0
   num_correct = 0
 
   for query, true_nn in zip(queries, true_nns):
     start = timeit.default_timer()
-    res = table.find_nearest_neighbor(query)
+    res = query_obj.find_nearest_neighbor(query)
     end = timeit.default_timer()
     average_query_time_outside += (end - start)
     if res == true_nn:
@@ -29,7 +29,7 @@ def run_experiment(table, queries, true_nns):
       average_query_time_outside))
   print('Empirical success probability: {}\n'.format(success_probability))
   print('Query statistics:')
-  stats = table.get_query_statistics()
+  stats = query_obj.get_query_statistics()
   print('Average total query time: {:e} seconds'.format(
       stats.average_total_query_time))
   print('Average LSH time:         {:e} seconds'.format(stats.average_lsh_time))
@@ -137,18 +137,18 @@ params_hp.seed = seed ^ 833840234
 print('Hyperplane hash\n')
 
 start = timeit.default_timer()
-hp_table = falconn.LSHIndex(params_hp)
-hp_table.setup(data)
-hp_table.set_num_probes(2464)
+hp_table = falconn.construct_table_dense_float(data, params_hp)
+hp_query_obj = hp_table.construct_query_object(-1, -1)
+hp_query_obj.set_num_probes(2464)
 stop = timeit.default_timer()
 hp_construction_time = stop - start
 
 print('k = {}'.format(params_hp.k))
 print('l = {}'.format(params_hp.l))
-print('Number of probes = {}'.format(hp_table.get_num_probes()))
+print('Number of probes = {}'.format(hp_query_obj.get_num_probes()))
 print('Construction time: {} seconds\n'.format(hp_construction_time))
 
-hp_avg_time, hp_success_prob = run_experiment(hp_table, queries, true_nns)
+hp_avg_time, hp_success_prob = run_experiment(hp_query_obj, queries, true_nns)
 del hp_table
 print(sepline)
 
@@ -168,9 +168,9 @@ params_cp.seed = seed ^ 833840234
 print('Cross polytope hash\n')
 
 start = timeit.default_timer()
-cp_table = falconn.LSHIndex(params_cp)
-cp_table.setup(data)
-cp_table.set_num_probes(896)
+cp_table = falconn.construct_table_dense_float(data, params_cp)
+cp_query_obj = cp_table.construct_query_object(-1, -1)
+cp_query_obj.set_num_probes(896)
 stop = timeit.default_timer()
 cp_construction_time = stop - start
 
@@ -178,10 +178,10 @@ print('k = {}'.format(params_cp.k))
 print('last_cp_dim = {}'.format(params_cp.last_cp_dimension))
 print('num_rotations = {}'.format(params_cp.num_rotations))
 print('l = {}'.format(params_cp.l))
-print('Number of probes = {}'.format(cp_table.get_num_probes()))
+print('Number of probes = {}'.format(cp_query_obj.get_num_probes()))
 print('Construction time: {} seconds\n'.format(cp_construction_time))
 
-cp_avg_time, cp_success_prob = run_experiment(cp_table, queries, true_nns)
+cp_avg_time, cp_success_prob = run_experiment(cp_query_obj, queries, true_nns)
 
 print(sepline)
 print('Summary:')

--- a/src/python/benchmark/random_benchmark.py
+++ b/src/python/benchmark/random_benchmark.py
@@ -11,67 +11,69 @@ sys.path.append('python_swig')
 
 import falconn
 
+
 def run_experiment(query_obj, queries, true_nns):
-  average_query_time_outside = 0.0
-  num_correct = 0
+    average_query_time_outside = 0.0
+    num_correct = 0
 
-  for query, true_nn in zip(queries, true_nns):
-    start = timeit.default_timer()
-    res = query_obj.find_nearest_neighbor(query)
-    end = timeit.default_timer()
-    average_query_time_outside += (end - start)
-    if res == true_nn:
-      num_correct += 1
+    for query, true_nn in zip(queries, true_nns):
+        start = timeit.default_timer()
+        res = query_obj.find_nearest_neighbor(query)
+        end = timeit.default_timer()
+        average_query_time_outside += (end - start)
+        if res == true_nn:
+            num_correct += 1
 
-  average_query_time_outside /= len(queries)
-  success_probability = float(num_correct) / len(queries)
-  print('Average query time (measured outside): {:e}'.format(
-      average_query_time_outside))
-  print('Empirical success probability: {}\n'.format(success_probability))
-  print('Query statistics:')
-  stats = query_obj.get_query_statistics()
-  print('Average total query time: {:e} seconds'.format(
-      stats.average_total_query_time))
-  print('Average LSH time:         {:e} seconds'.format(stats.average_lsh_time))
-  print('Average hash table time:  {:e} seconds'.format(
-      stats.average_hash_table_time))
-  print('Average distance time:    {:e} seconds'.format(
-      stats.average_distance_time))
-  print('Average number of candidates:        {}'.format(
-      stats.average_num_candidates))
-  print('Average number of unique candidates: {}\n'.format(
-      stats.average_num_unique_candidates))
-  print('Diagnostics:')
-  mismatch = average_query_time_outside - stats.average_total_query_time
-  print('Outside - inside average total query time: {:e} seconds ({:%})'.format(
-      mismatch, mismatch / average_query_time_outside))
-  unaccounted = stats.average_total_query_time - stats.average_lsh_time \
-      - stats.average_hash_table_time - stats.average_distance_time
-  print('Unaccounted inside query time: {:e} seconds ({:%})'.format(unaccounted,
-      unaccounted / stats.average_total_query_time))
-  return average_query_time_outside, float(num_correct) / len(queries)
+    average_query_time_outside /= len(queries)
+    success_probability = float(num_correct) / len(queries)
+    print('Average query time (measured outside): {:e}'.format(
+        average_query_time_outside))
+    print('Empirical success probability: {}\n'.format(success_probability))
+    print('Query statistics:')
+    stats = query_obj.get_query_statistics()
+    print('Average total query time: {:e} seconds'.format(
+        stats.average_total_query_time))
+    print('Average LSH time:         {:e} seconds'.format(
+        stats.average_lsh_time))
+    print('Average hash table time:  {:e} seconds'.format(
+        stats.average_hash_table_time))
+    print('Average distance time:    {:e} seconds'.format(
+        stats.average_distance_time))
+    print('Average number of candidates:        {}'.format(
+        stats.average_num_candidates))
+    print('Average number of unique candidates: {}\n'.format(
+        stats.average_num_unique_candidates))
+    print('Diagnostics:')
+    mismatch = average_query_time_outside - stats.average_total_query_time
+    print('Outside - inside average total query time: {:e} seconds ({:%})'.
+          format(mismatch, mismatch / average_query_time_outside))
+    unaccounted = stats.average_total_query_time - stats.average_lsh_time \
+        - stats.average_hash_table_time - stats.average_distance_time
+    print('Unaccounted inside query time: {:e} seconds ({:%})'.format(
+        unaccounted, unaccounted / stats.average_total_query_time))
+    return average_query_time_outside, float(num_correct) / len(queries)
 
 
 def gen_near_neighbor(v, r):
-  rp = np.random.randn(v.size)
-  rp = rp / np.linalg.norm(rp)
-  rp = rp - np.dot(rp, v) * v
-  rp = rp / np.linalg.norm(rp)
-  alpha = 1 - r * r / 2.0
-  beta = math.sqrt(1.0 - alpha * alpha)
-  return alpha * v + beta * rp
+    rp = np.random.randn(v.size)
+    rp = rp / np.linalg.norm(rp)
+    rp = rp - np.dot(rp, v) * v
+    rp = rp / np.linalg.norm(rp)
+    alpha = 1 - r * r / 2.0
+    beta = math.sqrt(1.0 - alpha * alpha)
+    return alpha * v + beta * rp
 
 
 def aligned(a, alignment=32):
-  if (a.ctypes.data % alignment) == 0:
-    return a
-  extra = alignment // a.itemsize
-  buf = np.empty(a.size + extra, dtype=a.dtype)
-  ofs = (-buf.ctypes.data % alignment) // a.itemsize
-  aa = buf[ofs:ofs+a.size].reshape(a.shape)
-  np.copyto(aa, a)
-  assert (aa.ctypes.data % alignment) == 0
-  return aa
+    if (a.ctypes.data % alignment) == 0:
+        return a
+    extra = alignment // a.itemsize
+    buf = np.empty(a.size + extra, dtype=a.dtype)
+    ofs = (-buf.ctypes.data % alignment) // a.itemsize
+    aa = buf[ofs:ofs + a.size].reshape(a.shape)
+    np.copyto(aa, a)
+    assert (aa.ctypes.data % alignment) == 0
+    return aa
 
 
 
@@ -106,19 +108,19 @@ data = aligned(data)
 print('Generating queries ...\n')
 queries = []
 for ii in range(num_queries):
-  q = gen_near_neighbor(data[np.random.randint(n)], r)
-  q = aligned(q)
-  queries.append(q.astype(np.float32))
+    q = gen_near_neighbor(data[np.random.randint(n)], r)
+    q = aligned(q)
+    queries.append(q.astype(np.float32))
 
 print('Computing true nearest neighbors via a linear scan ...')
 true_nns = []
 average_scan_time = 0.0
 for query in queries:
-  start = timeit.default_timer()
-  best_index = np.argmax(np.dot(data, query))
-  stop = timeit.default_timer()
-  true_nns.append(best_index)
-  average_scan_time += (stop - start)
+    start = timeit.default_timer()
+    best_index = np.argmax(np.dot(data, query))
+    stop = timeit.default_timer()
+    true_nns.append(best_index)
+    average_scan_time += (stop - start)
 average_scan_time /= num_queries
 print('Average query time: {} seconds'.format(average_scan_time))
 print(sepline)

--- a/src/python/benchmark/random_benchmark.py
+++ b/src/python/benchmark/random_benchmark.py
@@ -65,9 +65,9 @@ def gen_near_neighbor(v, r):
 def aligned(a, alignment=32):
   if (a.ctypes.data % alignment) == 0:
     return a
-  extra = alignment / a.itemsize
+  extra = alignment // a.itemsize
   buf = np.empty(a.size + extra, dtype=a.dtype)
-  ofs = (-buf.ctypes.data % alignment) / a.itemsize
+  ofs = (-buf.ctypes.data % alignment) // a.itemsize
   aa = buf[ofs:ofs+a.size].reshape(a.shape)
   np.copyto(aa, a)
   assert (aa.ctypes.data % alignment) == 0
@@ -137,18 +137,18 @@ params_hp.seed = seed ^ 833840234
 print('Hyperplane hash\n')
 
 start = timeit.default_timer()
-hp_table = falconn.construct_table_dense_float(data, params_hp)
-hp_query_obj = hp_table.construct_query_object(-1, -1)
-hp_query_obj.set_num_probes(2464)
+hp_table = falconn.LSHIndex(params_hp)
+hp_table.setup(data)
+hp_table.set_num_probes(2464)
 stop = timeit.default_timer()
 hp_construction_time = stop - start
 
 print('k = {}'.format(params_hp.k))
 print('l = {}'.format(params_hp.l))
-print('Number of probes = {}'.format(hp_query_obj.get_num_probes()))
+print('Number of probes = {}'.format(hp_table.get_num_probes()))
 print('Construction time: {} seconds\n'.format(hp_construction_time))
 
-hp_avg_time, hp_success_prob = run_experiment(hp_query_obj, queries, true_nns)
+hp_avg_time, hp_success_prob = run_experiment(hp_table, queries, true_nns)
 del hp_table
 print(sepline)
 
@@ -168,9 +168,9 @@ params_cp.seed = seed ^ 833840234
 print('Cross polytope hash\n')
 
 start = timeit.default_timer()
-cp_table = falconn.construct_table_dense_float(data, params_cp)
-cp_query_obj = cp_table.construct_query_object(-1, -1)
-cp_query_obj.set_num_probes(896)
+cp_table = falconn.LSHIndex(params_cp)
+cp_table.setup(data)
+cp_table.set_num_probes(896)
 stop = timeit.default_timer()
 cp_construction_time = stop - start
 
@@ -178,10 +178,10 @@ print('k = {}'.format(params_cp.k))
 print('last_cp_dim = {}'.format(params_cp.last_cp_dimension))
 print('num_rotations = {}'.format(params_cp.num_rotations))
 print('l = {}'.format(params_cp.l))
-print('Number of probes = {}'.format(cp_query_obj.get_num_probes()))
+print('Number of probes = {}'.format(cp_table.get_num_probes()))
 print('Construction time: {} seconds\n'.format(cp_construction_time))
 
-cp_avg_time, cp_success_prob = run_experiment(cp_query_obj, queries, true_nns)
+cp_avg_time, cp_success_prob = run_experiment(cp_table, queries, true_nns)
 
 print(sepline)
 print('Summary:')

--- a/src/python/package/__init__.py
+++ b/src/python/package/__init__.py
@@ -7,7 +7,8 @@ helper functions `get_default_parameters()` and
 `compute_number_of_hash_functions()`.
 
 For now, the Python wrapper supports only _static dense_ datasets,
-but more to come. Also, note that FALCONN is currently not thread-safe.
+but more to come. Also, note that the Python wrapper of FALCONN is
+currently not thread-safe.
 
 FALCONN is based on Locality-Sensitive Hashing (LSH), which is briefly
 covered [here](https://github.com/FALCONN-LIB/FALCONN/wiki/LSH-Primer)
@@ -68,7 +69,7 @@ def get_default_parameters(num_points, dimension, distance='euclidean_squared', 
     preprocessing, so if you are willing to build index for longer
     (and spend more memory) while reducing the query time, you need to
     increase the number of tables (`l`) in the resulting object.
-    
+
     The parameters returned are especially well-suited for _centered_
     datasets (when the mean is zero).
 
@@ -121,7 +122,7 @@ class LSHConstructionParameters(_internal.LSHConstructionParameters):
     Not all fields are necessary for all types of LSH. One can
     use `get_default_parameters()` and `computer_number_of_hash_functions()`
     to build an instance of `LSHConstructionParameters`.
-    
+
     Required parameters:
 
     * `dimension`: dimension of the points. Required for all the hash families;
@@ -231,7 +232,7 @@ class LSHIndex:
 
     See their respective documentation for help.
     """
-    
+
     def __init__(self, params):
         """Initialize with an instance of `LSHConstructionParameters`.
 
@@ -243,10 +244,11 @@ class LSHIndex:
         self._params = params
         self._dataset = None
         self._table = None
+        self._query_object = None
 
     def setup(self, dataset):
         """Build the LSH data structure from a given dataset.
-        
+
         The method builds the LSH data structure using the parameters
         passed during the construction and a given dataset (stored as
         `self._params`).
@@ -281,6 +283,7 @@ class LSHIndex:
             self._table = _internal.construct_table_dense_float(dataset, self._params)
         else:
             self._table = _internal.construct_table_dense_double(dataset, self._params)
+        self._query_object = self._table.construct_query_object(self._params.l, -1)
 
     def _check_built(self):
         if self._dataset is None or self._table is None:
@@ -314,8 +317,8 @@ class LSHIndex:
         self._check_query(query)
         if k <= 0:
             raise ValueError('k must be positive rather than {}'.format(k))
-        return self._table.find_k_nearest_neighbors(query, k)
-        
+        return self._query_object.find_k_nearest_neighbors(query, k)
+
     def find_near_neighbors(self, query, threshold):
         """Find all the points within `threshold` distance from `query`.
 
@@ -333,11 +336,11 @@ class LSHIndex:
         """
         self._check_built()
         self._check_query(query)
-        return self._table.find_near_neighbors(query, threshold)
-        
+        return self._query_object.find_near_neighbors(query, threshold)
+
     def find_nearest_neighbor(self, query):
         """Find the key of the closest candidate.
-        
+
         Finds the key of the closest candidate in the probing sequence
         for a query.
 
@@ -349,8 +352,8 @@ class LSHIndex:
         """
         self._check_built()
         self._check_query(query)
-        return self._table.find_nearest_neighbor(query)
-        
+        return self._query_object.find_nearest_neighbor(query)
+
     def get_candidates_with_duplicates(self, query):
         """Retrieve all the candidates for a given query.
 
@@ -368,18 +371,18 @@ class LSHIndex:
         """
         self._check_built()
         self._check_query(query)
-        return self._table.get_candidates_with_duplicates(query)
-        
+        return self._query_object.get_candidates_with_duplicates(query)
+
     def get_max_num_candidates(self):
         """Get the maximum number of candidates considered in each query."""
         self._check_built()
-        return self._table.get_max_num_candidates()
-        
+        return self._query_object.get_max_num_candidates()
+
     def get_num_probes(self):
         """Get the number of probes used for each query."""
         self._check_built()
-        return self._table.get_num_probes()
-        
+        return self._query_object.get_num_probes()
+
     def get_query_statistics(self):
         """Return the query statistics.
 
@@ -389,8 +392,8 @@ class LSHIndex:
         or the construction).
         """
         self._check_built()
-        return self._table.get_query_statistics()
-        
+        return self._query_object.get_query_statistics()
+
     def get_unique_candidates(self, query):
         """Retrieve all the candidates (each at most once) for a query.
 
@@ -406,13 +409,13 @@ class LSHIndex:
         """
         self._check_built()
         self._check_query(query)
-        return self._table.get_unique_candidates(query)
-                
+        return self._query_object.get_unique_candidates(query)
+
     def reset_query_statistics(self):
         """Reset the query statistics."""
         self._check_built()
-        self._table.reset_query_statistics()
-        
+        self._query_object.reset_query_statistics()
+
     def set_max_num_candidates(self, max_num_candidates=-1):
         """Set the maximum number of candidates considered in each query.
 
@@ -430,8 +433,8 @@ class LSHIndex:
         self._check_built()
         if max_num_candidates < -1:
             raise ValueError('invalid max_num_candidates: {}'.format(max_num_candidates))
-        self._table.set_max_num_candidates(max_num_candidates)
-        
+        self._query_object.set_max_num_candidates(max_num_candidates)
+
     def set_num_probes(self, num_probes):
         """Set the number of probes used for each query.
 
@@ -447,4 +450,4 @@ class LSHIndex:
         self._check_built()
         if num_probes < self._params.l:
             raise ValueError('number of probes must be at least the number of tables ({})'.format(self._params.l))
-        self._table.set_num_probes(num_probes)
+        self._query_object.set_num_probes(num_probes)

--- a/src/python/package/__init__.py
+++ b/src/python/package/__init__.py
@@ -61,7 +61,11 @@ performance of our LSH families.
 import numpy as _numpy
 from . import internal as _internal
 
-def get_default_parameters(num_points, dimension, distance='euclidean_squared', is_sufficiently_random=False):
+
+def get_default_parameters(num_points,
+                           dimension,
+                           distance='euclidean_squared',
+                           is_sufficiently_random=False):
     """Get parameters for `LSHIndex` for _reasonable_ datasets.
 
     This function returns an instance of `LSHConstructionParameters` that
@@ -88,7 +92,9 @@ def get_default_parameters(num_points, dimension, distance='euclidean_squared', 
     very few coordinates are zeros; in this case one is able to speed
     things up a little bit.
     """
-    return _internal.get_default_parameters(num_points, dimension, distance, is_sufficiently_random)
+    return _internal.get_default_parameters(num_points, dimension, distance,
+                                            is_sufficiently_random)
+
 
 def compute_number_of_hash_functions(num_bits, params):
     """Modify `params` such that each hash table has `2^num_bits` bins.
@@ -114,6 +120,7 @@ def compute_number_of_hash_functions(num_bits, params):
     fields partially set as described above
     """
     _internal.compute_number_of_hash_functions(num_bits, params)
+
 
 class LSHConstructionParameters(_internal.LSHConstructionParameters):
     """ Construction parameters for the LSH data structure.
@@ -159,6 +166,7 @@ class LSHConstructionParameters(_internal.LSHConstructionParameters):
     """
     pass
 
+
 class QueryStatistics(_internal.QueryStatistics):
     """Query statistics of the LSH data structure.
 
@@ -175,6 +183,7 @@ class QueryStatistics(_internal.QueryStatistics):
     * `average_total_query_time`: average overall query time.
     """
     pass
+
 
 class LSHIndex:
     """The main class that represents the LSH data structure.
@@ -277,13 +286,18 @@ class LSHIndex:
         if dataset.dtype != _numpy.float32 and dataset.dtype != _numpy.float64:
             raise ValueError('dataset must consist of floats or doubles')
         if dataset.shape[1] != self._params.dimension:
-            raise ValueError('dataset dimension mismatch: {} expected, but {} found'.format(self._params.dimension, dataset.shape[1]))
+            raise ValueError(
+                'dataset dimension mismatch: {} expected, but {} found'.format(
+                    self._params.dimension, dataset.shape[1]))
         self._dataset = dataset
         if dataset.dtype == _numpy.float32:
-            self._table = _internal.construct_table_dense_float(dataset, self._params)
+            self._table = _internal.construct_table_dense_float(
+                dataset, self._params)
         else:
-            self._table = _internal.construct_table_dense_double(dataset, self._params)
-        self._query_object = self._table.construct_query_object(self._params.l, -1)
+            self._table = _internal.construct_table_dense_double(
+                dataset, self._params)
+        self._query_object = self._table.construct_query_object(
+            self._params.l, -1)
 
     def _check_built(self):
         if self._dataset is None or self._table is None:
@@ -297,7 +311,9 @@ class LSHIndex:
         if self._dataset.dtype != query.dtype:
             raise ValueError('dataset and query must have the same dtype')
         if query.shape[0] != self._params.dimension:
-            raise ValueError('query dimension mismatch: {} expected, but {} found'.format(self._params.dimension, query.shape[0]))
+            raise ValueError(
+                'query dimension mismatch: {} expected, but {} found'.format(
+                    self._params.dimension, query.shape[0]))
 
     def find_k_nearest_neighbors(self, query, k):
         """Retrieve the closest `k` neighbors to `query`.
@@ -432,7 +448,8 @@ class LSHIndex:
         """
         self._check_built()
         if max_num_candidates < -1:
-            raise ValueError('invalid max_num_candidates: {}'.format(max_num_candidates))
+            raise ValueError(
+                'invalid max_num_candidates: {}'.format(max_num_candidates))
         self._query_object.set_max_num_candidates(max_num_candidates)
 
     def set_num_probes(self, num_probes):
@@ -449,5 +466,7 @@ class LSHIndex:
         """
         self._check_built()
         if num_probes < self._params.l:
-            raise ValueError('number of probes must be at least the number of tables ({})'.format(self._params.l))
+            raise ValueError(
+                'number of probes must be at least the number of tables ({})'.
+                format(self._params.l))
         self._query_object.set_num_probes(num_probes)

--- a/src/python/package/setup.py
+++ b/src/python/package/setup.py
@@ -4,7 +4,7 @@ import sys
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst', format='md')
-except(IOError, ImportError):
+except (IOError, ImportError):
     long_description = open('README.md').read()
 
 try:
@@ -24,22 +24,27 @@ if sys.platform == 'darwin':
     extra_args += ['-mmacosx-version-min=10.9', '-stdlib=libc++']
     os.environ['LDFLAGS'] = '-mmacosx-version-min=10.9'
 
-module = Extension('_falconn',
-                   sources=['falconn/swig/falconn_wrap.cc'],
-                   extra_compile_args=extra_args,
-                   include_dirs=['falconn/src/include',
-                                 'falconn/external/eigen',
-                                 np.get_include()])
+module = Extension(
+    '_falconn',
+    sources=['falconn/swig/falconn_wrap.cc'],
+    extra_compile_args=extra_args,
+    include_dirs=[
+        'falconn/src/include', 'falconn/external/eigen',
+        np.get_include()
+    ])
 
-setup(name='FALCONN',
-      version='1.2.2',
-      author='Ilya Razenshteyn, Ludwig Schmidt',
-      author_email='falconn.lib@gmail.com',
-      url='http://falconn-lib.org/',
-      description='A library for similarity search over high-dimensional data based on Locality-Sensitive Hashing (LSH)',
-      long_description=long_description,
-      license='MIT',
-      keywords='nearest neighbor search similarity lsh locality-sensitive hashing cosine distance euclidean',
-      packages=find_packages(),
-      include_package_data=True,
-      ext_modules=[module])
+setup(
+    name='FALCONN',
+    version='1.2.2',
+    author='Ilya Razenshteyn, Ludwig Schmidt',
+    author_email='falconn.lib@gmail.com',
+    url='http://falconn-lib.org/',
+    description=
+    'A library for similarity search over high-dimensional data based on Locality-Sensitive Hashing (LSH)',
+    long_description=long_description,
+    license='MIT',
+    keywords=
+    'nearest neighbor search similarity lsh locality-sensitive hashing cosine distance euclidean',
+    packages=find_packages(),
+    include_package_data=True,
+    ext_modules=[module])

--- a/src/python/test/module_test.py
+++ b/src/python/test/module_test.py
@@ -1,123 +1,125 @@
 import falconn
 import numpy as np
 
+
 def test_lsh_index_positive():
-  n = 1000
-  d = 128
-  p = falconn.get_default_parameters(n, d)
-  t = falconn.LSHIndex(p)
-  dataset = np.random.randn(n, d).astype(np.float32)
-  t.setup(dataset)
-  u = np.random.randn(d).astype(np.float32)
-  t.find_k_nearest_neighbors(u, 10)
-  t.find_near_neighbors(u, 10.0)
-  t.find_nearest_neighbor(u)
-  t.get_candidates_with_duplicates(u)
-  t.get_max_num_candidates()
-  t.get_num_probes()
-  t.get_query_statistics()
-  t.get_unique_candidates(u)
-  #t.get_unique_sorted_candidates(u)
-  t.reset_query_statistics()
-  t.set_max_num_candidates(100)
-  t.set_num_probes(10)
+    n = 1000
+    d = 128
+    p = falconn.get_default_parameters(n, d)
+    t = falconn.LSHIndex(p)
+    dataset = np.random.randn(n, d).astype(np.float32)
+    t.setup(dataset)
+    u = np.random.randn(d).astype(np.float32)
+    t.find_k_nearest_neighbors(u, 10)
+    t.find_near_neighbors(u, 10.0)
+    t.find_nearest_neighbor(u)
+    t.get_candidates_with_duplicates(u)
+    t.get_max_num_candidates()
+    t.get_num_probes()
+    t.get_query_statistics()
+    t.get_unique_candidates(u)
+    #t.get_unique_sorted_candidates(u)
+    t.reset_query_statistics()
+    t.set_max_num_candidates(100)
+    t.set_num_probes(10)
+
 
 def test_lsh_index_negative():
-  n = 1000
-  d = 128
-  p = falconn.get_default_parameters(n, d)
-  t = falconn.LSHIndex(p)
-  try:
-    t.find_nearest_neighbor(np.random.randn(d))
-    assert False
-  except RuntimeError:
-    pass
-  try:
-    dataset = [[1.0, 2.0], [3.0, 4.0]]
-    t.setup(dataset)
-    assert False
-  except TypeError:
-    pass
-  try:
-    dataset = np.random.randn(n, d).astype(np.int32)
-    t.setup(dataset)
-    assert False
-  except ValueError:
-    pass
-  try:
-    dataset = np.random.randn(10, 10, 10)
-    t.setup(dataset)
-    assert False
-  except ValueError:
-    pass
-  dataset = np.random.randn(n, d).astype(np.float32)
-  t.setup(dataset)
-  dataset = np.random.randn(n, d).astype(np.float64)
-  t.setup(dataset)
-  u = np.random.randn(d).astype(np.float64)
-  
-  try:
-    t.find_k_nearest_neighbors(u, 0.5)
-    assert False
-  except TypeError:
-    pass
-
-  try:
-    t.find_k_nearest_neighbors(u, -1)
-    assert False
-  except ValueError:
-    pass
-  
-  t.find_near_neighbors(u, -1)
-  
-  try:
-    t.set_max_num_candidates(0.5)
-    assert False
-  except TypeError:
-    pass
-  try:
-    t.set_max_num_candidates(-10)
-    assert False
-  except ValueError:
-    pass
-  t.set_num_probes(t._params.l)
-  try:
-    t.set_num_probes(t._params.l - 1)
-    assert False
-  except ValueError:
-    pass
-  try:
-    t.set_num_probes(1000.1)
-    assert False
-  except TypeError:
-    pass
-
-  def check_check_query(f):
+    n = 1000
+    d = 128
+    p = falconn.get_default_parameters(n, d)
+    t = falconn.LSHIndex(p)
     try:
-      f(u.astype(np.float32))
-      assert False
-    except ValueError:
-      pass
+        t.find_nearest_neighbor(np.random.randn(d))
+        assert False
+    except RuntimeError:
+        pass
     try:
-      f([0.0] * d)
-      assert False
+        dataset = [[1.0, 2.0], [3.0, 4.0]]
+        t.setup(dataset)
+        assert False
     except TypeError:
-      pass
+        pass
     try:
-      f(u[:d-1])
-      assert False
+        dataset = np.random.randn(n, d).astype(np.int32)
+        t.setup(dataset)
+        assert False
     except ValueError:
-      pass
+        pass
     try:
-      f(np.random.randn(d, d))
-      assert False
+        dataset = np.random.randn(10, 10, 10)
+        t.setup(dataset)
+        assert False
     except ValueError:
-      pass
+        pass
+    dataset = np.random.randn(n, d).astype(np.float32)
+    t.setup(dataset)
+    dataset = np.random.randn(n, d).astype(np.float64)
+    t.setup(dataset)
+    u = np.random.randn(d).astype(np.float64)
 
-  check_check_query(lambda u: t.find_k_nearest_neighbors(u, 10))
-  check_check_query(lambda u: t.find_near_neighbors(u, 0.5))
-  check_check_query(lambda u: t.find_nearest_neighbor(u))
-  check_check_query(lambda u: t.get_candidates_with_duplicates(u))
-  check_check_query(lambda u: t.get_unique_candidates(u))
-  #check_check_query(lambda u: t.get_unique_sorted_candidates(u))
-  t.find_near_neighbors(u, 0.0)
+    try:
+        t.find_k_nearest_neighbors(u, 0.5)
+        assert False
+    except TypeError:
+        pass
+
+    try:
+        t.find_k_nearest_neighbors(u, -1)
+        assert False
+    except ValueError:
+        pass
+
+    t.find_near_neighbors(u, -1)
+
+    try:
+        t.set_max_num_candidates(0.5)
+        assert False
+    except TypeError:
+        pass
+    try:
+        t.set_max_num_candidates(-10)
+        assert False
+    except ValueError:
+        pass
+    t.set_num_probes(t._params.l)
+    try:
+        t.set_num_probes(t._params.l - 1)
+        assert False
+    except ValueError:
+        pass
+    try:
+        t.set_num_probes(1000.1)
+        assert False
+    except TypeError:
+        pass
+
+    def check_check_query(f):
+        try:
+            f(u.astype(np.float32))
+            assert False
+        except ValueError:
+            pass
+        try:
+            f([0.0] * d)
+            assert False
+        except TypeError:
+            pass
+        try:
+            f(u[:d - 1])
+            assert False
+        except ValueError:
+            pass
+        try:
+            f(np.random.randn(d, d))
+            assert False
+        except ValueError:
+            pass
+
+    check_check_query(lambda u: t.find_k_nearest_neighbors(u, 10))
+    check_check_query(lambda u: t.find_near_neighbors(u, 0.5))
+    check_check_query(lambda u: t.find_nearest_neighbor(u))
+    check_check_query(lambda u: t.get_candidates_with_duplicates(u))
+    check_check_query(lambda u: t.get_unique_candidates(u))
+    #check_check_query(lambda u: t.get_unique_sorted_candidates(u))
+    t.find_near_neighbors(u, 0.0)

--- a/src/python/test/wrapper_test.py
+++ b/src/python/test/wrapper_test.py
@@ -4,45 +4,46 @@ sys.path.append('python_swig')
 import falconn
 import numpy as np
 
+
 def test_number_of_hash_functions():
-  params = falconn.LSHConstructionParameters()
-  
-  params.lsh_family = 'hyperplane'
-  params.dimension = 10
-  falconn.compute_number_of_hash_functions(5, params)
-  assert params.k == 5
-  
-  params.lsh_family = 'cross_polytope'
-  falconn.compute_number_of_hash_functions(5, params)
-  assert params.k == 1
-  assert params.last_cp_dimension == 16
+    params = falconn.LSHConstructionParameters()
 
-  params.dimension = 100
-  params.lsh_family = 'hyperplane'
-  falconn.compute_number_of_hash_functions(8, params)
-  assert params.k == 8
-  
-  params.lsh_family = 'cross_polytope'
-  falconn.compute_number_of_hash_functions(8, params)
-  assert params.k == 1
-  assert params.last_cp_dimension == 128
+    params.lsh_family = 'hyperplane'
+    params.dimension = 10
+    falconn.compute_number_of_hash_functions(5, params)
+    assert params.k == 5
 
-  falconn.compute_number_of_hash_functions(10, params)
-  assert params.k == 2
-  assert params.last_cp_dimension == 2
+    params.lsh_family = 'cross_polytope'
+    falconn.compute_number_of_hash_functions(5, params)
+    assert params.k == 1
+    assert params.last_cp_dimension == 16
+
+    params.dimension = 100
+    params.lsh_family = 'hyperplane'
+    falconn.compute_number_of_hash_functions(8, params)
+    assert params.k == 8
+
+    params.lsh_family = 'cross_polytope'
+    falconn.compute_number_of_hash_functions(8, params)
+    assert params.k == 1
+    assert params.last_cp_dimension == 128
+
+    falconn.compute_number_of_hash_functions(10, params)
+    assert params.k == 2
+    assert params.last_cp_dimension == 2
 
 
 def test_get_default_parameters():
-  n = 100000
-  dim = 128
-  dist_func = 'negative_inner_product'
-  params = falconn.get_default_parameters(n, dim, dist_func, True)
-  assert params.l == 10
-  assert params.lsh_family == 'cross_polytope'
-  assert params.storage_hash_table == 'bit_packed_flat_hash_table'
-  assert params.num_setup_threads == 0
-  assert params.k == 2
-  assert params.dimension == dim
-  assert params.distance_function == dist_func
-  assert params.num_rotations == 1
-  assert params.last_cp_dimension == 64
+    n = 100000
+    dim = 128
+    dist_func = 'negative_inner_product'
+    params = falconn.get_default_parameters(n, dim, dist_func, True)
+    assert params.l == 10
+    assert params.lsh_family == 'cross_polytope'
+    assert params.storage_hash_table == 'bit_packed_flat_hash_table'
+    assert params.num_setup_threads == 0
+    assert params.k == 2
+    assert params.dimension == dim
+    assert params.distance_function == dist_func
+    assert params.num_rotations == 1
+    assert params.last_cp_dimension == 64

--- a/src/python/wrapper/python_wrapper.h
+++ b/src/python/wrapper/python_wrapper.h
@@ -23,7 +23,7 @@ class PyLSHNearestNeighborQueryDenseDouble {
   typedef LSHNearestNeighborQuery<DenseVector<double>, int32_t> InnerQuery;
   typedef LSHNearestNeighborTable<DenseVector<double>, int32_t> InnerTable;
   typedef Eigen::Map<const DenseVector<double>> ConstVectorMap;
-  
+
   PyLSHNearestNeighborQueryDenseDouble(InnerQuery* query) : query_(query) {}
 
   int find_nearest_neighbor(const double* vec, int len) {
@@ -38,7 +38,7 @@ class PyLSHNearestNeighborQueryDenseDouble {
     query_->find_k_nearest_neighbors(q, k, &result);
     return result;
   }
-  
+
   std::vector<int32_t> find_near_neighbors(const double* vec, int len,
                                            double threshold) {
     ConstVectorMap q(vec, len);
@@ -65,7 +65,7 @@ class PyLSHNearestNeighborQueryDenseDouble {
   int_fast32_t get_num_probes() {
     return query_->get_num_probes();
   }
-  
+
   void set_num_probes(int_fast32_t new_num_probes) {
     query_->set_num_probes(new_num_probes);
   }
@@ -77,7 +77,7 @@ class PyLSHNearestNeighborQueryDenseDouble {
   void set_max_num_candidates(int_fast32_t new_max_num_candidates) {
     query_->set_max_num_candidates(new_max_num_candidates);
   }
-  
+
   void reset_query_statistics() {
     return query_->reset_query_statistics();
   }
@@ -85,7 +85,7 @@ class PyLSHNearestNeighborQueryDenseDouble {
   falconn::QueryStatistics get_query_statistics() {
     return query_->get_query_statistics();
   }
- 
+
  private:
   std::shared_ptr<InnerQuery> query_ = nullptr;
 };
@@ -96,7 +96,7 @@ class PyLSHNearestNeighborQueryPoolDenseDouble {
       InnerQueryPool;
   typedef LSHNearestNeighborTable<DenseVector<double>, int32_t> InnerTable;
   typedef Eigen::Map<const DenseVector<double>> ConstVectorMap;
-  
+
   PyLSHNearestNeighborQueryPoolDenseDouble(InnerQueryPool* query_pool)
     : query_pool_(query_pool) {}
 
@@ -112,7 +112,7 @@ class PyLSHNearestNeighborQueryPoolDenseDouble {
     query_pool_->find_k_nearest_neighbors(q, k, &result);
     return result;
   }
-  
+
   std::vector<int32_t> find_near_neighbors(const double* vec, int len,
                                            double threshold) {
     ConstVectorMap q(vec, len);
@@ -139,7 +139,7 @@ class PyLSHNearestNeighborQueryPoolDenseDouble {
   int_fast32_t get_num_probes() {
     return query_pool_->get_num_probes();
   }
-  
+
   void set_num_probes(int_fast32_t new_num_probes) {
     query_pool_->set_num_probes(new_num_probes);
   }
@@ -151,7 +151,7 @@ class PyLSHNearestNeighborQueryPoolDenseDouble {
   void set_max_num_candidates(int_fast32_t new_max_num_candidates) {
     query_pool_->set_max_num_candidates(new_max_num_candidates);
   }
-  
+
   void reset_query_statistics() {
     return query_pool_->reset_query_statistics();
   }
@@ -159,7 +159,7 @@ class PyLSHNearestNeighborQueryPoolDenseDouble {
   falconn::QueryStatistics get_query_statistics() {
     return query_pool_->get_query_statistics();
   }
- 
+
  private:
   std::shared_ptr<InnerQueryPool> query_pool_ = nullptr;
 };
@@ -178,7 +178,7 @@ class PyLSHNearestNeighborTableDenseDouble {
                                                        max_num_candidates)));
     return PyLSHNearestNeighborQueryDenseDouble(query.release());
   }
-  
+
   PyLSHNearestNeighborQueryPoolDenseDouble construct_query_pool(
       int_fast32_t num_probes,
       int_fast32_t max_num_candidates,
@@ -199,7 +199,7 @@ class PyLSHNearestNeighborQueryDenseFloat {
   typedef LSHNearestNeighborQuery<DenseVector<float>, int32_t> InnerQuery;
   typedef LSHNearestNeighborTable<DenseVector<float>, int32_t> InnerTable;
   typedef Eigen::Map<const DenseVector<float>> ConstVectorMap;
-  
+
   PyLSHNearestNeighborQueryDenseFloat(InnerQuery* query) : query_(query) {}
 
   int find_nearest_neighbor(const float* vec, int len) {
@@ -214,7 +214,7 @@ class PyLSHNearestNeighborQueryDenseFloat {
     query_->find_k_nearest_neighbors(q, k, &result);
     return result;
   }
-  
+
   std::vector<int32_t> find_near_neighbors(const float* vec, int len,
                                            float threshold) {
     ConstVectorMap q(vec, len);
@@ -241,7 +241,7 @@ class PyLSHNearestNeighborQueryDenseFloat {
   int_fast32_t get_num_probes() {
     return query_->get_num_probes();
   }
-  
+
   void set_num_probes(int_fast32_t new_num_probes) {
     query_->set_num_probes(new_num_probes);
   }
@@ -253,7 +253,7 @@ class PyLSHNearestNeighborQueryDenseFloat {
   void set_max_num_candidates(int_fast32_t new_max_num_candidates) {
     query_->set_max_num_candidates(new_max_num_candidates);
   }
-  
+
   void reset_query_statistics() {
     return query_->reset_query_statistics();
   }
@@ -261,7 +261,7 @@ class PyLSHNearestNeighborQueryDenseFloat {
   falconn::QueryStatistics get_query_statistics() {
     return query_->get_query_statistics();
   }
- 
+
  private:
   std::shared_ptr<InnerQuery> query_ = nullptr;
 };
@@ -272,7 +272,7 @@ class PyLSHNearestNeighborTableDenseFloat {
   typedef Eigen::Map<const DenseVector<float>> ConstVectorMap;
 
   PyLSHNearestNeighborTableDenseFloat(InnerTable* table) : table_(table) {}
-  
+
   PyLSHNearestNeighborQueryDenseFloat construct_query_object(
       int_fast32_t num_probes, int_fast32_t max_num_candidates) {
     std::unique_ptr<LSHNearestNeighborQuery<DenseVector<float>, int32_t>>

--- a/src/python/wrapper/python_wrapper.h
+++ b/src/python/wrapper/python_wrapper.h
@@ -62,9 +62,7 @@ class PyLSHNearestNeighborQueryDenseDouble {
     return result;
   }
 
-  int_fast32_t get_num_probes() {
-    return query_->get_num_probes();
-  }
+  int_fast32_t get_num_probes() { return query_->get_num_probes(); }
 
   void set_num_probes(int_fast32_t new_num_probes) {
     query_->set_num_probes(new_num_probes);
@@ -78,9 +76,7 @@ class PyLSHNearestNeighborQueryDenseDouble {
     query_->set_max_num_candidates(new_max_num_candidates);
   }
 
-  void reset_query_statistics() {
-    return query_->reset_query_statistics();
-  }
+  void reset_query_statistics() { return query_->reset_query_statistics(); }
 
   falconn::QueryStatistics get_query_statistics() {
     return query_->get_query_statistics();
@@ -98,7 +94,7 @@ class PyLSHNearestNeighborQueryPoolDenseDouble {
   typedef Eigen::Map<const DenseVector<double>> ConstVectorMap;
 
   PyLSHNearestNeighborQueryPoolDenseDouble(InnerQueryPool* query_pool)
-    : query_pool_(query_pool) {}
+      : query_pool_(query_pool) {}
 
   int find_nearest_neighbor(const double* vec, int len) {
     ConstVectorMap q(vec, len);
@@ -136,9 +132,7 @@ class PyLSHNearestNeighborQueryPoolDenseDouble {
     return result;
   }
 
-  int_fast32_t get_num_probes() {
-    return query_pool_->get_num_probes();
-  }
+  int_fast32_t get_num_probes() { return query_pool_->get_num_probes(); }
 
   void set_num_probes(int_fast32_t new_num_probes) {
     query_pool_->set_num_probes(new_num_probes);
@@ -174,19 +168,17 @@ class PyLSHNearestNeighborTableDenseDouble {
   PyLSHNearestNeighborQueryDenseDouble construct_query_object(
       int_fast32_t num_probes, int_fast32_t max_num_candidates) {
     std::unique_ptr<LSHNearestNeighborQuery<DenseVector<double>, int32_t>>
-        query(std::move(table_->construct_query_object(num_probes,
-                                                       max_num_candidates)));
+        query(std::move(
+            table_->construct_query_object(num_probes, max_num_candidates)));
     return PyLSHNearestNeighborQueryDenseDouble(query.release());
   }
 
   PyLSHNearestNeighborQueryPoolDenseDouble construct_query_pool(
-      int_fast32_t num_probes,
-      int_fast32_t max_num_candidates,
+      int_fast32_t num_probes, int_fast32_t max_num_candidates,
       int_fast32_t num_query_objects) {
     std::unique_ptr<LSHNearestNeighborQueryPool<DenseVector<double>, int32_t>>
-        query_pool(std::move(table_->construct_query_pool(num_probes,
-                                                          max_num_candidates,
-                                                          num_query_objects)));
+        query_pool(std::move(table_->construct_query_pool(
+            num_probes, max_num_candidates, num_query_objects)));
     return PyLSHNearestNeighborQueryPoolDenseDouble(query_pool.release());
   }
 
@@ -238,9 +230,7 @@ class PyLSHNearestNeighborQueryDenseFloat {
     return result;
   }
 
-  int_fast32_t get_num_probes() {
-    return query_->get_num_probes();
-  }
+  int_fast32_t get_num_probes() { return query_->get_num_probes(); }
 
   void set_num_probes(int_fast32_t new_num_probes) {
     query_->set_num_probes(new_num_probes);
@@ -254,9 +244,7 @@ class PyLSHNearestNeighborQueryDenseFloat {
     query_->set_max_num_candidates(new_max_num_candidates);
   }
 
-  void reset_query_statistics() {
-    return query_->reset_query_statistics();
-  }
+  void reset_query_statistics() { return query_->reset_query_statistics(); }
 
   falconn::QueryStatistics get_query_statistics() {
     return query_->get_query_statistics();
@@ -275,9 +263,9 @@ class PyLSHNearestNeighborTableDenseFloat {
 
   PyLSHNearestNeighborQueryDenseFloat construct_query_object(
       int_fast32_t num_probes, int_fast32_t max_num_candidates) {
-    std::unique_ptr<LSHNearestNeighborQuery<DenseVector<float>, int32_t>>
-        query(std::move(table_->construct_query_object(num_probes,
-                                                       max_num_candidates)));
+    std::unique_ptr<LSHNearestNeighborQuery<DenseVector<float>, int32_t>> query(
+        std::move(
+            table_->construct_query_object(num_probes, max_num_candidates)));
     return PyLSHNearestNeighborQueryDenseFloat(query.release());
   }
 

--- a/src/test/cpp_wrapper_test.cc
+++ b/src/test/cpp_wrapper_test.cc
@@ -48,12 +48,14 @@ void basic_test_dense_1(const LSHConstructionParameters& params) {
 
   unique_ptr<LSHNearestNeighborTable<Point>> table(
       std::move(construct_table<Point>(points, params)));
+  unique_ptr<LSHNearestNeighborQuery<Point>> query(
+      std::move(table->construct_query_object()));
 
-  int32_t res1 = table->find_nearest_neighbor(p1);
+  int32_t res1 = query->find_nearest_neighbor(p1);
   EXPECT_EQ(0, res1);
-  int32_t res2 = table->find_nearest_neighbor(p2);
+  int32_t res2 = query->find_nearest_neighbor(p2);
   EXPECT_EQ(1, res2);
-  int32_t res3 = table->find_nearest_neighbor(p3);
+  int32_t res3 = query->find_nearest_neighbor(p3);
   EXPECT_EQ(2, res3);
 
   Point p4(dim);
@@ -61,7 +63,7 @@ void basic_test_dense_1(const LSHConstructionParameters& params) {
   p4[1] = 1.0;
   p4[2] = 0.0;
   p4[3] = 0.0;
-  int32_t res4 = table->find_nearest_neighbor(p4);
+  int32_t res4 = query->find_nearest_neighbor(p4);
   EXPECT_EQ(1, res4);
 }
 
@@ -81,51 +83,19 @@ void basic_test_sparse_1(const LSHConstructionParameters& params) {
 
   unique_ptr<LSHNearestNeighborTable<Point>> table(
       std::move(construct_table<Point>(points, params)));
+  unique_ptr<LSHNearestNeighborQuery<Point>> query(
+      std::move(table->construct_query_object()));
 
-  int32_t res1 = table->find_nearest_neighbor(p1);
+  int32_t res1 = query->find_nearest_neighbor(p1);
   EXPECT_EQ(0, res1);
-  int32_t res2 = table->find_nearest_neighbor(p2);
+  int32_t res2 = query->find_nearest_neighbor(p2);
   EXPECT_EQ(1, res2);
-  int32_t res3 = table->find_nearest_neighbor(p3);
+  int32_t res3 = query->find_nearest_neighbor(p3);
   EXPECT_EQ(2, res3);
 
   Point p4;
   p4.push_back(make_pair(7, 1.0));
-  int32_t res4 = table->find_nearest_neighbor(p4);
-  EXPECT_EQ(1, res4);
-}
-
-void basic_test_query_object_1(const LSHConstructionParameters& params) {
-  typedef SparseVector<float> Point;
-  Point p1;
-  p1.push_back(make_pair(24, 1.0));
-  Point p2;
-  p2.push_back(make_pair(7, 0.8));
-  p2.push_back(make_pair(24, 0.6));
-  Point p3;
-  p3.push_back(make_pair(50, 1.0));
-  vector<Point> points;
-  points.push_back(p1);
-  points.push_back(p2);
-  points.push_back(p3);
-
-  unique_ptr<LSHNearestNeighborTable<Point>> table(
-      std::move(construct_table<Point>(points, params)));
-
-  unique_ptr<LSHNearestNeighborQuery<Point>> nn_query(
-          std::move(table->construct_query_object()));
-
-
-  int32_t res1 = nn_query->find_nearest_neighbor(p1);
-  EXPECT_EQ(0, res1);
-  int32_t res2 = nn_query->find_nearest_neighbor(p2);
-  EXPECT_EQ(1, res2);
-  int32_t res3 = nn_query->find_nearest_neighbor(p3);
-  EXPECT_EQ(2, res3);
-
-  Point p4;
-  p4.push_back(make_pair(7, 1.0));
-  int32_t res4 = nn_query->find_nearest_neighbor(p4);
+  int32_t res4 = query->find_nearest_neighbor(p4);
   EXPECT_EQ(1, res4);
 }
 
@@ -172,21 +142,6 @@ TEST(WrapperTest, SparseHPTest1) {
 
   basic_test_sparse_1(params);
 }
-
-TEST(WrapperTest, LSHNNQueryTest1) {
-  int dim = 100;
-  LSHConstructionParameters params;
-  params.dimension = dim;
-  params.lsh_family = LSHFamily::Hyperplane;
-  params.distance_function = DistanceFunction::NegativeInnerProduct;
-  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
-  params.k = 2;
-  params.l = 4;
-  params.num_setup_threads = 0;
-
-  basic_test_query_object_1(params);
-}
-
 
 TEST(WrapperTest, SparseCPTest1) {
   int dim = 100;

--- a/src/test/cpp_wrapper_test.cc
+++ b/src/test/cpp_wrapper_test.cc
@@ -14,6 +14,7 @@ using falconn::LSHConstructionParameters;
 using falconn::LSHFamily;
 using falconn::LSHNearestNeighborTable;
 using falconn::LSHNearestNeighborQuery;
+using falconn::LSHNearestNeighborQueryPool;
 using falconn::get_default_parameters;
 using falconn::SparseVector;
 using falconn::StorageHashTable;
@@ -47,9 +48,9 @@ void basic_test_dense_1(const LSHConstructionParameters& params) {
   points.push_back(p3);
 
   unique_ptr<LSHNearestNeighborTable<Point>> table(
-      std::move(construct_table<Point>(points, params)));
+      construct_table<Point>(points, params));
   unique_ptr<LSHNearestNeighborQuery<Point>> query(
-      std::move(table->construct_query_object()));
+      table->construct_query_object());
 
   int32_t res1 = query->find_nearest_neighbor(p1);
   EXPECT_EQ(0, res1);
@@ -64,6 +65,20 @@ void basic_test_dense_1(const LSHConstructionParameters& params) {
   p4[2] = 0.0;
   p4[3] = 0.0;
   int32_t res4 = query->find_nearest_neighbor(p4);
+  EXPECT_EQ(1, res4);
+  
+  unique_ptr<LSHNearestNeighborQueryPool<Point>> query_pool(
+      table->construct_query_pool());
+ 
+  // Same queries as above but now through a query pool
+  res1 = query_pool->find_nearest_neighbor(p1);
+  EXPECT_EQ(0, res1);
+  res2 = query_pool->find_nearest_neighbor(p2);
+  EXPECT_EQ(1, res2);
+  res3 = query_pool->find_nearest_neighbor(p3);
+  EXPECT_EQ(2, res3);
+
+  res4 = query_pool->find_nearest_neighbor(p4);
   EXPECT_EQ(1, res4);
 }
 
@@ -82,9 +97,9 @@ void basic_test_sparse_1(const LSHConstructionParameters& params) {
   points.push_back(p3);
 
   unique_ptr<LSHNearestNeighborTable<Point>> table(
-      std::move(construct_table<Point>(points, params)));
+      construct_table<Point>(points, params));
   unique_ptr<LSHNearestNeighborQuery<Point>> query(
-      std::move(table->construct_query_object()));
+      table->construct_query_object());
 
   int32_t res1 = query->find_nearest_neighbor(p1);
   EXPECT_EQ(0, res1);

--- a/src/test/cpp_wrapper_test.cc
+++ b/src/test/cpp_wrapper_test.cc
@@ -13,6 +13,7 @@ using falconn::DistanceFunction;
 using falconn::LSHConstructionParameters;
 using falconn::LSHFamily;
 using falconn::LSHNearestNeighborTable;
+using falconn::LSHNearestNeighborQuery;
 using falconn::get_default_parameters;
 using falconn::SparseVector;
 using falconn::StorageHashTable;
@@ -94,6 +95,40 @@ void basic_test_sparse_1(const LSHConstructionParameters& params) {
   EXPECT_EQ(1, res4);
 }
 
+void basic_test_query_object_1(const LSHConstructionParameters& params) {
+  typedef SparseVector<float> Point;
+  Point p1;
+  p1.push_back(make_pair(24, 1.0));
+  Point p2;
+  p2.push_back(make_pair(7, 0.8));
+  p2.push_back(make_pair(24, 0.6));
+  Point p3;
+  p3.push_back(make_pair(50, 1.0));
+  vector<Point> points;
+  points.push_back(p1);
+  points.push_back(p2);
+  points.push_back(p3);
+
+  unique_ptr<LSHNearestNeighborTable<Point>> table(
+      std::move(construct_table<Point>(points, params)));
+
+  unique_ptr<LSHNearestNeighborQuery<Point>> nn_query(
+          std::move(table->construct_query_object()));
+
+
+  int32_t res1 = nn_query->find_nearest_neighbor(p1);
+  EXPECT_EQ(0, res1);
+  int32_t res2 = nn_query->find_nearest_neighbor(p2);
+  EXPECT_EQ(1, res2);
+  int32_t res3 = nn_query->find_nearest_neighbor(p3);
+  EXPECT_EQ(2, res3);
+
+  Point p4;
+  p4.push_back(make_pair(7, 1.0));
+  int32_t res4 = nn_query->find_nearest_neighbor(p4);
+  EXPECT_EQ(1, res4);
+}
+
 TEST(WrapperTest, DenseHPTest1) {
   int dim = 4;
   LSHConstructionParameters params;
@@ -137,6 +172,21 @@ TEST(WrapperTest, SparseHPTest1) {
 
   basic_test_sparse_1(params);
 }
+
+TEST(WrapperTest, LSHNNQueryTest1) {
+  int dim = 100;
+  LSHConstructionParameters params;
+  params.dimension = dim;
+  params.lsh_family = LSHFamily::Hyperplane;
+  params.distance_function = DistanceFunction::NegativeInnerProduct;
+  params.storage_hash_table = StorageHashTable::BitPackedFlatHashTable;
+  params.k = 2;
+  params.l = 4;
+  params.num_setup_threads = 0;
+
+  basic_test_query_object_1(params);
+}
+
 
 TEST(WrapperTest, SparseCPTest1) {
   int dim = 100;

--- a/src/test/cpp_wrapper_test.cc
+++ b/src/test/cpp_wrapper_test.cc
@@ -66,10 +66,10 @@ void basic_test_dense_1(const LSHConstructionParameters& params) {
   p4[3] = 0.0;
   int32_t res4 = query->find_nearest_neighbor(p4);
   EXPECT_EQ(1, res4);
-  
+
   unique_ptr<LSHNearestNeighborQueryPool<Point>> query_pool(
       table->construct_query_pool());
- 
+
   // Same queries as above but now through a query pool
   res1 = query_pool->find_nearest_neighbor(p1);
   EXPECT_EQ(0, res1);

--- a/src/test/test_utils.h
+++ b/src/test/test_utils.h
@@ -239,11 +239,11 @@ void run_retrieve_test_6(HashTable* table) {
   std::vector<int32_t> expected_result3 = {1, 2};
   IteratorPair result3 = table->retrieve(5);
   check_result(result3, expected_result3);
-  
+
   std::vector<int32_t> expected_result4 = {};
   IteratorPair result4 = table->retrieve(6);
   check_result(result4, expected_result4);
-  
+
   std::vector<int32_t> expected_result5 = {};
   IteratorPair result5 = table->retrieve(7);
   check_result(result5, expected_result5);


### PR DESCRIPTION
I simply added a new abstarct class LSHNearestNeighborQuery like LSHNearestNeighborTable which wraps Query. I couldn't add a metthod to LSHNearestNeighborTable which returns directley Query object, because Query couldn't be resolved in lsh_nn_table.h (we need forward declaration perhaps?).
