### PR TITLE
Fix setup.py build / pip install on OS X

### DIFF
--- a/src/python/package/setup.py
+++ b/src/python/package/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 try:
@@ -18,9 +19,14 @@ except ImportError:
     sys.stderr.write('NumPy not found!\n')
     raise
 
+extra_args = ['-std=c++11', '-march=native', '-O3']
+if sys.platform == 'darwin':
+    extra_args += ['-mmacosx-version-min=10.9', '-stdlib=libc++']
+    os.environ['LDFLAGS'] = '-mmacosx-version-min=10.9'
+
 module = Extension('_falconn',
                    sources=['falconn/swig/falconn_wrap.cc'],
-                   extra_compile_args=['-std=c++11', '-march=native', '-O3'],
+                   extra_compile_args=extra_args,
                    include_dirs=['falconn/src/include',
                                  'falconn/external/eigen',
                                  np.get_include()])


### PR DESCRIPTION
Hi Ludwig + Ilya,

I tried to `pip install falconn` and found that it failed to compile on OS X, so 
I went ahead and fixed it.

Specifically, the current setup.py fails to use a version of the standard library 
with C++11 support, and so chokes when attempting to include <type_traits>. 
The fix is to explicitly set which standard library to use and ensure the 
minimum required OS X version is set such that it's willing to use this library.

Note that this is with clang, because OS X g++ is an alias for clang with some
directories in /Developer added to the include path by default.

FYI / for people googling similar errors, the exact error message was:

    In file included from falconn/swig/falconn_wrap.cc:3687:
    In file included from falconn/src/include/falconn/falconn_global.h:8:
    In file included from falconn/src/include/falconn/eigen_wrapper.h:11:
    In file included from falconn/external/eigen/Eigen/Dense:1:
    falconn/external/eigen/Eigen/Core:257:10: fatal error: 'type_traits' file not found
    #include <type_traits>
             ^
    1 error generated.

