### PR TITLE
add prefetching in topk pipe

### DIFF
--- a/src/include/falconn/experimental/pipes.h
+++ b/src/include/falconn/experimental/pipes.h
@@ -449,12 +449,18 @@ class TopKPipeThreadUnsafe {
     h_.reset();
     h_.resize(k_);
     int32_t initially_inserted = 0;
+    if (g.is_valid()) {
+      s.prepare(worker_id, g.get());
+    }
     for (; initially_inserted < k_; ++initially_inserted) {
       if (g.is_valid()) {
         auto val = g.get();
         auto score = s.get_score(worker_id, val);
         h_.insert_unsorted(-score, val);
         ++g;
+        if (g.is_valid()) {
+          s.prepare(worker_id, g.get());
+        }
       } else {
         break;
       }
@@ -497,9 +503,15 @@ class TopKPipeThreadUnsafe {
       }
 
       if (look_ahead_ == 0) {
+        if (g.is_valid()) {
+          s.prepare(worker_id, g.get());
+        }
         while (g.is_valid()) {
           auto val = g.get();
           ++g;
+          if (g.is_valid()) {
+            s.prepare(worker_id, g.get());
+          }
 
           auto score = s.get_score(worker_id, val);
           if (score < -h_.min_key()) {

--- a/src/test/pipes_test.cc
+++ b/src/test/pipes_test.cc
@@ -26,12 +26,12 @@ std::vector<DenseVector<float>> get_dummy_dataset(int32_t n) {
 
 TEST(TopKPipeTest, TestLookaheads) {
   const int32_t n = 100;
-  const int32_t k = 7;
+  const int32_t k = 10;
   std::vector<DenseVector<float>> dataset = get_dummy_dataset(n);
   DenseVector<float> query(1);
   query[0] = 0;
 
-  for (int32_t lookahead = 1; lookahead <= k; lookahead++) {
+  for (int32_t lookahead = 0; lookahead <= k; lookahead++) {
     ExhaustiveProducer producer(1, n);
     DistanceScorer<DenseVector<float>> scorer(1, dataset);
     TopKPipe<DistanceScorer<DenseVector<float>>> top_k(1, k, true, lookahead);
@@ -44,7 +44,7 @@ TEST(TopKPipeTest, TestLookaheads) {
       ans.push_back(it1.get());
       ++it1;
     }
-    ASSERT_THAT(ans, ::testing::ElementsAre(0, 1, 2, 3, 4, 5, 6));
+    ASSERT_THAT(ans, ::testing::ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
   }
 }
 


### PR DESCRIPTION
this adds the missing pre-fetching when inserting the first `k` elements to the heap, and also when `lookahead = 0`.